### PR TITLE
Add planet-geophys tag, Venus and Titan surface

### DIFF
--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -91,14 +91,26 @@
         "Implied Evolutionary Differences of the Jovian Irregular Satellites from a BVR Color Survey",
         "DOI: 10.1006/icar.2001.6715", "https://www.sciencedirect.com/science/article/abs/pii/S0019103501967156"
     ],
-    "Mercury|Mallama2017": {"tags": ["featured", "solar_system", "planet"],
+    "Maiorov2005": [
+        "A New Analysis of the Spectra Obtained by the Venera Missions in the Venusian Atmosphere. I. The Analysis of the Data Received from the Venera-11 Probe at Altitudes Below 37 km in the 0.44–0.66 µm Wavelength Range",
+        "DOI: 10.1007/s11208-005-0042-1", "https://link.springer.com/article/10.1007/s11208-005-0042-1"
+    ]
+    "Karkoschka2012": [
+        "The reflectivity spectrum and opposition effect of Titan's surface observed by Huygens' DISR spectrometers",
+        "DOI: 10.1016/j.pss.2011.10.014", "https://www.sciencedirect.com/science/article/pii/S0032063311003254"
+    ]
+    "Karkoschka2016": [
+        "Eight-color maps of Titan’s surface from spectroscopy with Huygens’ DISR",
+        "DOI: 10.1016/j.icarus.2015.06.010", "https://www.sciencedirect.com/science/article/pii/S0019103515002547"
+    ]
+    "Mercury|Mallama2017": {"tags": ["featured", "solar_system", "planet-geophys", "planet"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.087, 0.105, 0.142, 0.158, 0.172, 0.180, 0.208], "albedo": true
     },
-    "Mercury|Crow2011": {"tags": ["solar_system", "planet"],
+    "Mercury|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [314.7, 359.0, 392.6, 415.5, 457.5, 501.2, 626.4, 729.7, 959.5, 1063.5], "br": [0.61, 0.56, 0.66, 0.71, 0.86, 1.00, 1.37, 1.50, 1.77, 2.01],
         "albedo": 0.142
     },
-    "Mercury|Madden2018": {"tags": ["solar_system", "planet"],
+    "Mercury|Madden2018": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [299.63, 315.33, 335.22, 348.71, 366.62, 385.46, 406.4, 429.43, 448.27, 467.11, 490.14, 513.17, 536.2, 559.23, 582.25, 605.28, 628.31,
         651.34, 674.37, 697.4, 720.43, 743.46, 766.49, 789.51, 812.54, 835.57, 858.6, 881.63, 904.66, 927.69, 950.72, 973.74, 996.77],
         "br": [0.00765, 0.00849, 0.00927, 0.01017, 0.01104, 0.01178, 0.01255, 0.01318, 0.01378, 0.01455, 0.01536, 0.01595, 0.01637, 0.01665, 0.01706,
@@ -106,28 +118,33 @@
         0.02258, 0.02302],
         "albedo": true
     },
-    "Venus|Mallama2017": {"tags": ["featured", "solar_system", "planet"],
+    "Venus|Mallama2017": {"tags": ["featured", "solar_system", "planet-geophys", "planet"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.348, 0.658, 0.689, 0.658, 0.708, 0.640, 0.584], "albedo": true
     },
-    "Venus|Crow2011": {"tags": ["solar_system", "planet"],
+    "Venus|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [314.7, 359.0, 392.6, 415.5, 457.5, 501.2, 626.4, 729.7, 959.5, 1063.5], "br": [0.59, 0.64, 0.72, 0.58, 0.95, 1.00, 1.16, 1.08, 1.16, 1.12],
         "albedo": 0.689
     },
-    "Venus|Madden2018": {"tags": ["solar_system", "planet"],
+    "Venus|Madden2018": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [480.52, 600.74, 722.74, 807.16, 887.92, 966.48, 996.22],
         "br": [0.4762, 0.46407, 0.45882, 0.45564, 0.44893, 0.44337, 0.42979],
         "albedo": true
     },
-    "Earth|Mallama2017": {"tags": ["solar_system", "planet"],
+    "Venus Surface|Maiorov2005": {"tags": ["featured", "solar_system", "planet-geophys", "planet"],
+        "nm": [440, 450, 460, 470, 480, 490, 500, 700],
+        "br": [0.089, 0.092, 0.095, 0.097, 0.098, 0.099, 0.1, 0.1],
+        "albedo": true
+    },
+    "Earth|Mallama2017": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.688, 0.512, 0.434, 0.392, 0.418, 0.396, 0.430], "albedo": true
     },
-    "Earth|Crow2011": {"tags": ["featured", "solar_system", "planet"],
+    "Earth|Crow2011": {"tags": ["featured", "solar_system", "planet-geophys", "planet"],
         "nm": [350, 450, 550, 650, 750, 850, 950], "br": [1610.47, 1342.71, 1059.02, 1014.27, 1062.25, 1168.00, 853.79], "albedo": 0.434
     },
-    "Moon|Crow2011": {"tags": ["featured", "solar_system", "moon"],
+    "Moon|Crow2011": {"tags": ["featured", "solar_system", "planet-geophys", "moon"],
         "nm": [350, 450, 550, 650, 750, 850, 950], "br": [13.83, 18.06, 22.54, 26.68, 30.74, 34.86, 34.14], "albedo": 0.09948, // |Madden2018
     },
-    "Moon|Madden2018": {"tags": ["solar_system", "moon"],
+    "Moon|Madden2018": {"tags": ["solar_system", "planet-geophys", "moon"],
         "nm_range": [450, 890, 5],
         "br": [0.12894, 0.12827, 0.12833, 0.12049, 0.12152, 0.11801, 0.11888, 0.10276, 0.10624, 0.10734, 0.10659, 0.10483, 0.10482, 0.10586, 0.10583, 0.10377, 
         0.10273, 0.10111, 0.10124, 0.09872, 0.09948, 0.09881, 0.09755, 0.09794, 0.09592, 0.09507, 0.09502, 0.0956, 0.09492, 0.09621, 0.09716, 0.0979, 0.09899,
@@ -137,20 +154,20 @@
         0.11203, 0.11971, 0.10748, 0.11364, 0.10462, 0.10882],
         "albedo": true
     },
-    "Mars|Mallama2017": {"tags": ["solar_system", "planet"],
+    "Mars|Mallama2017": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.060, 0.088, 0.170, 0.250, 0.288, 0.285, 0.330], "albedo": true
     },
-    "Mars|Crow2011": {"tags": ["solar_system", "planet"],
+    "Mars|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [350, 450, 550, 650, 750, 850, 950], "br": [4.52, 6.87, 13.09, 21.60, 25.32, 26.55, 24.31], "albedo": 0.170
     },
-    "Mars:B|USGSarchive": {"tags": ["featured", "solar_system", "planet", "surface_feature"],
+    "Mars:B|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "planet", "surface_feature"],
         "nm": [330, 342, 363, 381, 404, 440, 475, 504, 540, 566, 600, 633, 666, 700, 704.7, 716.4, 728.9, 739.8, 751.9, 763.6, 775.6, 786.3, 799, 811.7,
         822.4, 837.1, 849.8, 862.5],
         "br": [0.091700, 0.095981, 0.108666, 0.098961, 0.130791, 0.180553, 0.247580, 0.302547, 0.398298, 0.527668, 0.704229, 0.790133, 0.861244, 0.907984,
         0.927670, 0.950918, 0.968006, 0.973932, 1.007903, 1.009743, 0.983539, 0.998712, 1.002135, 0.990941, 0.984577, 0.981692, 0.969340, 0.963597],
         "albedo": 0.26, // https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2001JE001580
     },
-    "Mars:D|USGSarchive": {"tags": ["featured", "solar_system", "planet", "surface_feature"],
+    "Mars:D|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "planet", "surface_feature"],
         "nm": [330, 342, 363, 381, 404, 440, 475, 504, 540, 566, 600, 633, 644.1, 656, 667.9, 679.9, 691.7, 704.7, 716.4, 728.9, 739.8, 751.9, 763.6,
         775.6, 786.3, 799, 811.7, 822.4, 837.1, 849.8, 862.5],
         "br": [0.214259, 0.225981, 0.208343, 0.207151, 0.242350, 0.304599, 0.368299, 0.435753, 0.552943, 0.686686, 0.832221, 0.931029, 1.086725, 1.096983, 
@@ -158,7 +175,7 @@
         1.026548, 1.020545, 1.028644],
         "albedo": 0.12, // https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2001JE001580
     },
-    "Mars|Madden2018": {"tags": ["solar_system", "planet"],
+    "Mars|Madden2018": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [316.04, 360.96, 389.97, 435.05, 464.12, 502.86, 528.88, 567.92, 597.46, 626.82, 659.28, 697.97, 717.38, 762.51, 804.31, 846.12, 900.65,
         951.86, 993.64],
         "br": [0.04554, 0.04851, 0.05933, 0.07176, 0.0866, 0.10343, 0.12899, 0.16342, 0.20522, 0.23077, 0.24945, 0.25602, 0.26244, 0.26437, 0.2722, 0.28349,
@@ -177,70 +194,70 @@
         "br": [0.04, 0.05, 0.051, 0.05, 0.049, 0.053, 0.055, 0.058, 0.062, 0.067, 0.069],
         "albedo": 0.068, // Geom. ! https://ssd.jpl.nasa.gov/?sat_phys_par
     },
-    "Jupiter|Mallama2017": {"tags": ["solar_system", "planet", "jovian_system"],
+    "Jupiter|Mallama2017": {"tags": ["solar_system", "planet-geophys", "planet", "jovian_system"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.358, 0.443, 0.538, 0.513, 0.495, 0.389, 0.321]
     },
-    "Jupiter|Crow2011": {"tags": ["solar_system", "planet", "jovian_system"],
+    "Jupiter|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet", "jovian_system"],
         "nm": [350, 450, 550, 650, 750, 850], "br": [0.604, 0.824, 1.000, 1.006, 0.832, 0.636]
     },
-    "Jupiter|Karkoschka1994": {"tags": ["featured", "solar_system", "planet", "jovian_system"],
+    "Jupiter|Karkoschka1994": {"tags": ["featured", "solar_system", "planet-geophys", "planet", "jovian_system"],
         "file": "files/Karkoschka1994/jupiter.txt", "albedo": true
     },
-    "Io:T|USGSarchive": {"tags": ["featured", "solar_system", "moon", "jovian_system", "regular"],
+    "Io:T|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [350, 375, 400, 433, 466, 500, 533, 566, 600, 633, 666, 700, 733, 739.8, 751.9, 763.6, 775.6, 786.3, 799, 811.7, 822.4, 837.1, 849.8, 862.5],
         "br": [0.126856, 0.161157, 0.189998, 0.312668, 0.455349, 0.642046, 0.775382, 0.801427, 0.811630, 0.890139, 0.942953, 1.004252, 1.005697, 1.015561,
         1.031987, 1.019722, 1.008961, 1.000501, 1.015732, 1.006328, 1.003697, 0.986871, 0.973683, 0.987817],
         "albedo": 0.5014384, // |Madden2018
     },
-    "Io|Madden2018": {"tags": ["solar_system", "moon", "jovian_system", "regular"],
+    "Io|Madden2018": {"tags": ["solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [295.98, 349.54, 376.84, 395.48, 405.46, 428.85, 443.62, 475.98, 538.43, 600.68, 672.13, 787.28, 880.37, 964.69],
         "br": [0.06645, 0.09565, 0.13699, 0.18699, 0.24564, 0.31289, 0.39051, 0.46464, 0.49727, 0.51954, 0.56077, 0.57946, 0.5982, 0.62042],
         "albedo": true
     },
-    "Europa:T|USGSarchive": {"tags": ["featured", "solar_system", "moon", "jovian_system", "regular"],
+    "Europa:T|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [350, 375, 400, 433, 466, 500, 533, 566, 600, 633, 666, 700, 733, 766, 800, 833, 866],
         "br": [0.352826, 0.410782, 0.467415, 0.602579, 0.688769, 0.806425, 0.839300, 0.852109, 0.913667, 0.961235, 0.979446, 1.006591, 1.026941, 1.038414,
         1.067850, 1.062889, 1.063046],
         "albedo": 0.6110393, // |Madden2018
     },
-    "Europa:T|Madden2018": {"tags": ["solar_system", "moon", "jovian_system", "regular"],
+    "Europa:T|Madden2018": {"tags": ["solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [340.98, 358.07, 375.17, 381.3, 391.27, 419.79, 441.32, 451.3, 459.94, 468.22, 476.49, 484.82, 492.05, 503.62, 518.47, 551.04, 598.92, 647.01,
         695.29, 743.72, 792.14, 840.63, 889.18, 931.13, 954.13, 995.11],
         "br": [0.38563, 0.40049, 0.41506, 0.42872, 0.44588, 0.46115, 0.47493, 0.49191, 0.50931, 0.52444, 0.53987, 0.55339, 0.5672, 0.58258, 0.59866, 0.61138,
         0.62658, 0.63586, 0.63949, 0.639, 0.63841, 0.63616, 0.63216, 0.6371, 0.64146, 0.62304],
         "albedo": true
     },
-    "Ganymede:L|USGSarchive": {"tags": ["featured", "solar_system", "moon", "jovian_system", "regular"],
+    "Ganymede:L|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [350, 375, 400, 433, 466, 500, 533, 566, 600, 633, 666, 700, 733, 766, 800, 833, 866],
         "br": [0.488778, 0.590744, 0.632155, 0.752500, 0.783059, 0.869610, 0.918507, 0.955278, 0.973874, 1.010833, 1.021557, 1.046712, 1.040900, 1.035977,
         1.049606, 1.044146, 1.036557],
         "albedo": 0.4636778, // |Madden2018
     },
-    "Ganymede:L|Madden2018": {"tags": ["solar_system", "moon", "jovian_system", "regular"],
+    "Ganymede:L|Madden2018": {"tags": ["solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [320.0, 336.21, 352.99, 363.67, 377.95, 388.61, 404.13, 424.95, 446.14, 463.01, 478.07, 506.08, 548.23, 573.42, 625.63, 680.99, 715.56,
         779.75, 830.75, 876.4, 932.56, 968.8],
         "br": [0.24109, 0.26866, 0.29261, 0.30188, 0.32175, 0.34435, 0.36224, 0.37519, 0.39892, 0.42008, 0.4301, 0.44725, 0.463, 0.47268, 0.49018, 0.50107,
         0.49825, 0.48741, 0.48884, 0.49226, 0.49704, 0.49245],
         "albedo": true
     },
-    "Callisto:L|USGSarchive": {"tags": ["featured", "solar_system", "moon", "jovian_system", "regular"],
+    "Callisto:L|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [350, 375, 400, 433, 466, 500, 533, 566, 600, 633, 666, 700, 733, 766, 800, 833, 837.1, 849.8, 862.5],
         "br": [0.406242, 0.456089, 0.518130, 0.652152, 0.691349, 0.777651, 0.840575, 0.881522, 0.918704, 0.941487, 0.969265, 0.990831, 0.997041, 0.993501,
         1.007422, 0.986979, 1.001239, 0.985442, 1.006188],
         "albedo": 0.1688978, // |Madden2018
     },
-    "Callisto:L|Madden2018": {"tags": ["solar_system", "moon", "jovian_system", "regular"],
+    "Callisto:L|Madden2018": {"tags": ["solar_system", "planet-geophys", "moon", "jovian_system", "regular"],
         "nm": [353.4, 377.13, 402.86, 433.37, 496.32, 544.31, 592.48, 640.67, 666.97, 745.88, 794.39, 842.94, 891.47, 926.57],
         "br": [0.0891, 0.10305, 0.12241, 0.1311, 0.15594, 0.16799, 0.17514, 0.18138, 0.18453, 0.19318, 0.19019, 0.18602, 0.18271, 0.18578],
         "albedo": true
     },
-    "Saturn|Mallama2017": {"tags": ["solar_system", "planet", "saturnian_system"],
+    "Saturn|Mallama2017": {"tags": ["solar_system", "planet-geophys", "planet", "saturnian_system"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.203, 0.339, 0.499, 0.646, 0.568, 0.543, 0.423]
     },
-    "Saturn|Crow2011": {"tags": ["solar_system", "planet", "saturnian_system"],
+    "Saturn|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet", "saturnian_system"],
         "nm": [350, 450, 550, 650, 750, 850], "br": [0.445, 0.684, 1.000, 1.144, 1.001, 0.776]
     },
-    "Saturn|Karkoschka1994": {"tags": ["featured", "solar_system", "planet", "saturnian_system"],
+    "Saturn|Karkoschka1994": {"tags": ["featured", "solar_system", "planet-geophys", "planet", "saturnian_system"],
         "file": "files/Karkoschka1994/saturn.txt", "albedo": true
     },
     "Rings|USGSarchive": {"tags": ["featured", "solar_system", "ring", "saturnian_system"],
@@ -251,7 +268,7 @@
         1.016596],
         "albedo": 0.5
     },
-    "Enceladus|Madden2018": {"tags": ["featured", "solar_system", "moon", "saturnian_system", "regular"],
+    "Enceladus|Madden2018": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "nm_range": [350, 885, 5],
         "br": [0.8816, 0.87372, 0.87059, 0.87494, 0.86546, 0.85415, 0.84686, 0.85811, 0.86617, 0.8733, 0.88373, 0.8831, 0.87806, 0.87006, 0.86713, 0.86532,
         0.86426, 0.87688, 0.88714, 0.88488, 0.89243, 0.89924, 0.90296, 0.90052, 0.90437, 0.91443, 0.91511, 0.91539, 0.92768, 0.92002, 0.91779, 0.9203,
@@ -262,23 +279,23 @@
         0.84243, 0.84372, 0.84021, 0.84098, 0.84359, 0.84824, 0.84469, 0.84304, 0.8458, 0.84796, 0.85031, 0.85254],
         "albedo": true
     },
-    "Tethys|Filacchione2018": {"tags": ["featured", "solar_system", "moon", "saturnian_system", "regular"],
+    "Tethys|Filacchione2018": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "nm": [350, 440, 550, 700, 950],
         "br": [0.75042, 0.77108, 0.79707, 0.76842, 0.74823],
         "albedo": true
     },
-    "Dione|Filacchione2017": {"tags": ["featured", "solar_system", "moon", "saturnian_system", "regular"],
+    "Dione|Filacchione2017": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "nm": [350, 440, 550, 700, 950],
         "br": [0.57582, 0.61407, 0.61977, 0.58411, 0.58268],
         "albedo": true
     },
-    "Rhea|USGSarchive": {"tags": ["featured", "solar_system", "moon", "saturnian_system", "regular"],
+    "Rhea|USGSarchive": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "nm": [325, 350, 375, 400, 433, 466, 500, 533, 566, 600, 633, 666, 700, 733, 766, 800, 833, 866],
         "br": [0.734770, 0.732256, 0.745028, 0.844831, 0.859745, 0.910340, 0.925726, 0.991097, 0.992538, 1.016375, 1.006958, 1.049296, 1.060323, 1.034402,
         1.082394, 1.054788, 1.060017, 1.028328],
         "albedo": 0.75691, // |Madden2018
     },
-    "Rhea|Madden2018": {"tags": ["solar_system", "moon", "saturnian_system", "regular"],
+    "Rhea|Madden2018": {"tags": ["solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "nm_range": [450, 890, 5],
         "br": [0.80064, 0.79731, 0.82162, 0.79365, 0.83878, 0.81235, 0.85642, 0.80113, 0.8009, 0.79458, 0.78575, 0.77766, 0.77484, 0.78457, 0.76513, 0.76585, 
         0.76538, 0.75955, 0.77142, 0.75809, 0.75691, 0.75356, 0.74991, 0.74386, 0.73731, 0.72666, 0.72249, 0.73429, 0.71973, 0.71943, 0.71654, 0.71214,
@@ -288,46 +305,60 @@
         0.59506, 0.52898, 0.57511, 0.53865, 0.54182, 0.55485, 0.51589, 0.53527],
         "albedo": true
     },
-    "Titan|Crow2011": {"tags": ["solar_system", "moon", "saturnian_system", "regular"],
+    "Titan|Crow2011": {"tags": ["solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "nm": [350, 450, 550, 650, 750, 850], "br": [0.344, 0.584, 1.000, 1.248, 1.101, 0.879]
     },
-    "Titan|Karkoschka1994": {"tags": ["featured", "solar_system", "moon", "saturnian_system", "regular"],
+    "Titan|Karkoschka1994": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
         "file": "files/Karkoschka1994/titan.txt", "albedo": true
     },
-    "Uranus|Mallama2017": {"tags": ["solar_system", "planet", "uranian_system"],
+    "Titan surface (Huygens)|Karkoschka2012": {"tags": ["solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
+        "nm_range": [300, 801, 10],
+        "br": [0.025, 0.035, 0.046, 0.059, 0.073, 0.089, 0.105, 0.122, 0.140, 0.158, 
+               0.176, 0.194, 0.211, 0.229, 0.245, 0.261, 0.277, 0.292, 0.306, 0.319, 
+               0.331, 0.343, 0.354, 0.364, 0.373, 0.382, 0.390, 0.398, 0.404, 0.411, 
+               0.416, 0.421, 0.426, 0.430, 0.434, 0.437, 0.440, 0.442, 0.444, 0.446, 
+               0.447, 0.448, 0.449, 0.449, 0.450, 0.450, 0.450, 0.449, 0.449, 0.448, 0.447],
+		"albedo": true
+    },
+    "Titan surface (Huygens)|Karkoschka2016": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "saturnian_system", "regular"],
+        "nm": [520, 563, 595, 642, 685, 754, 823, 830, 935, 940, 1070, 1280, 1550, 1590],
+        "br": [0.093, 0.107, 0.116, 0.130, 0.139, 0.147, 0.151, 0.151, 0.151, 0.151, 0.145, 0.124, 0.070, 0.071],
+        "albedo": true
+    },
+    "Uranus|Mallama2017": {"tags": ["solar_system", "planet-geophys", "planet", "uranian_system"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.502, 0.561, 0.488, 0.264, 0.202, 0.089, 0.079]
     },
-    "Uranus|Crow2011": {"tags": ["solar_system", "planet", "uranian_system"],
+    "Uranus|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet", "uranian_system"],
         "nm": [350, 450, 550, 650, 750, 850], "br": [0.984, 1.067, 1.000, 0.647, 0.292, 0.148]
     },
-    "Uranus|Karkoschka1994": {"tags": ["featured", "solar_system", "planet", "uranian_system"],
+    "Uranus|Karkoschka1994": {"tags": ["featured", "solar_system", "planet-geophys", "planet", "uranian_system"],
         "file": "files/Karkoschka1994/uranus.txt", "albedo": true
     },
-    "Miranda|Avramchuk2007": {"tags": ["featured", "solar_system", "moon", "uranian_system", "regular"],
+    "Miranda|Avramchuk2007": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "uranian_system", "regular"],
         "nm": [250, 410, 480, 560, 750, 910], "br": [0.51, 0.49, 0.48, 0.47, 0.46, 0.45], "albedo": true, // spherical is 0.34
     },
-    "Ariel|Avramchuk2007": {"tags": ["featured", "solar_system", "moon", "uranian_system", "regular"],
+    "Ariel|Avramchuk2007": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "uranian_system", "regular"],
         "nm": [250, 410, 480, 560, 750, 910], "br": [0.50, 0.51, 0.51, 0.51, 0.51, 0.52], "albedo": true, // spherical is 0.37
     },
-    "Umbriel|Avramchuk2007": {"tags": ["featured", "solar_system", "moon", "uranian_system", "regular"],
+    "Umbriel|Avramchuk2007": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "uranian_system", "regular"],
         "nm": [250, 410, 480, 560, 750, 910], "br": [0.25, 0.25, 0.25, 0.25, 0.26, 0.26], "albedo": true, // spherical is 0.19
     },
-    "Titania|Avramchuk2007": {"tags": ["featured", "solar_system", "moon", "uranian_system", "regular"],
+    "Titania|Avramchuk2007": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "uranian_system", "regular"],
         "nm": [250, 410, 480, 560, 750, 910], "br": [0.30, 0.32, 0.33, 0.34, 0.36, 0.37], "albedo": true, // spherical is 0.27
     },
-    "Oberon|Avramchuk2007": {"tags": ["featured", "solar_system", "moon", "uranian_system", "regular"],
+    "Oberon|Avramchuk2007": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "uranian_system", "regular"],
         "nm": [250, 410, 480, 560, 750, 910], "br": [0.27, 0.29, 0.30, 0.31, 0.33, 0.35], "albedo": true, // spherical is 0.23
     },
-    "Neptune|Mallama2017": {"tags": ["solar_system", "planet"],
+    "Neptune|Mallama2017": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.578, 0.562, 0.442, 0.226, 0.181, 0.072, 0.067]
     },
-    "Neptune|Crow2011": {"tags": ["solar_system", "planet"],
+    "Neptune|Crow2011": {"tags": ["solar_system", "planet-geophys", "planet"],
         "nm": [350, 450, 550, 650, 750, 850], "br": [1.252, 1.235, 1.000, 0.555, 0.237, 0.132]
     },
-    "Neptune|Karkoschka1994": {"tags": ["featured", "solar_system", "planet", "neptunian_system"],
+    "Neptune|Karkoschka1994": {"tags": ["featured", "solar_system", "planet-geophys", "planet", "neptunian_system"],
         "file": "files/Karkoschka1994/neptune.txt", "albedo": true
     },
-    "Triton|Tryka1999": {"tags": ["featured", "solar_system", "moon", "neptunian_system", "irregular"],
+    "Triton|Tryka1999": {"tags": ["featured", "solar_system", "planet-geophys", "moon", "neptunian_system", "irregular"],
         "nm_range": [300, 900, 100],
         "br": [0.57, 0.67, 0.75, 0.77, 0.82, 0.81, 0.79],
         "albedo": true, // Geom. !
@@ -355,11 +386,11 @@
     //"Vanth|Howett2019": {"tags": ["solar_system", "minor_body", "tno", "plutino", "moon"],
     //	"filters": "Hubble", "bands": ["F606W", "F814W", "F110W", "F160W"], "mag": [21.73, 20.90, 23.3, 24.0], "vega": false
     //},
-    "(90482) Orcus|Howett2019": {"tags": ["solar_system", "minor_body", "dwarf_planet", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"V-I": 0.73}
+    "(90482) Orcus|Howett2019": {"tags": ["solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "plutino"],
+        "filters": "Landolt", "indices": {"V-I": 0.73}
     },
     "Vanth|Howett2019": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"V-I": 1.03}
+        "filters": "Landolt", "indices": {"V-I": 1.03}
     },
     "(101955) Bennu|LeCorre2019": {"tags": ["featured", "solar_system", "minor_body", "asteroid", "main_belt"],
         "nm": [473.228, 549.146, 697.569, 847.937],
@@ -371,14 +402,14 @@
         "br": [0.01604, 0.01573, 0.016, 0.01605],
         "albedo": true
     },
-    "(134340) Pluto|Lorenzi2016": {"tags": ["featured", "solar_system", "minor_body", "dwarf_planet", "tno", "plutino"],
+    "(134340) Pluto|Lorenzi2016": {"tags": ["featured", "solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "plutino"],
         "nm": [400.551, 423.678, 440.749, 458.37, 466.079, 493.062, 496.366, 499.119, 553.634, 555.837, 559.692, 582.819, 587.225, 630.727, 658.811, 
         670.925, 680.286, 697.907, 729.846, 761.233, 762.885, 773.348, 784.912, 790.419, 795.925, 803.084, 807.489, 812.996, 816.85, 836.674],
         "br": [0.642, 0.695, 0.766, 0.799, 0.832, 0.887, 0.872, 0.902, 1.019, 1.012, 1.031, 1.056, 1.07, 1.121, 1.137, 0.735, 1.156, 1.169, 1.152, 
         1.18, 1.157, 1.172, 1.099, 1.144, 1.118, 0.988, 1.072, 1.062, 1.135, 1.169],
         "albedo": 0.52
     },
-    "(134340) Pluto|Madden2018": {"tags": ["solar_system", "minor_body", "dwarf_planet", "tno", "plutino"],
+    "(134340) Pluto|Madden2018": {"tags": ["solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "plutino"],
         "nm": [410, 420, 430, 440, 450, 460, 470, 480, 490, 500, 510, 520, 530, 540, 550, 560, 570, 580, 590, 600, 610, 620, 630, 640, 650, 660, 670,
         680, 690, 700, 710, 720, 730, 740, 750, 760, 770, 780, 790, 800, 810, 820, 830, 840, 850, 860, 870, 880, 890, 900, 910, 920, 930, 992.71],
         "br": [0.31848, 0.33024, 0.34045, 0.36136, 0.38311, 0.39087, 0.40592, 0.42545, 0.43835, 0.44743, 0.4584, 0.46743, 0.48603, 0.49388, 0.50692,
@@ -387,19 +418,19 @@
         0.60355, 0.48914, 0.56542, 0.62153, 0.62718, 0.62923, 0.53279],
         "albedo": true
     },
-    "(136199) Eris|Lorenzi2016": {"tags": ["featured", "solar_system", "dwarf_planet", "minor_body", "tno", "detached"],
+    "(136199) Eris|Lorenzi2016": {"tags": ["featured", "solar_system", "planet-geophys", "dwarf_planet", "minor_body", "tno", "detached"],
         "nm": [417.357, 479.507, 532.699, 585.89, 601.008, 604.367, 622.844, 637.962, 653.08, 656.439, 659.239, 673.236, 679.955, 692.273, 702.912, 
         712.43, 734.267, 740.426, 747.704, 750.504, 765.062, 779.059, 788.578, 793.617, 809.295, 813.774, 826.652, 841.209, 860.246],
         "br": [0.995, 1.059, 1.084, 1.101, 1.08, 1.104, 1.111, 1.103, 1.121, 1.104, 1.11, 1.097, 1.117, 1.034, 1.121, 1.13, 1.11, 1.073, 1.11, 1.077, 
         1.132, 1.138, 1.087, 1.126, 1.018, 1.079, 0.881, 1.072, 1.13],
-        "albedo": 0.957, // albedo from Zelario's sheet
+        "albedo": 0.957, // albedo from zelario's sheet
     },
-    "(136472) Makemake|Lorenzi2016": {"tags": ["featured", "solar_system", "minor_body", "dwarf_planet", "tno", "classical", "classical-h"],
+    "(136472) Makemake|Lorenzi2016": {"tags": ["featured", "solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "classical", "classical-h"],
         "nm": [417.357, 466.069, 588.13, 601.568, 609.406, 631.243, 642.441, 649.72, 656.439, 664.278, 672.116, 679.955, 691.153, 706.271, 715.789,
         723.628, 729.787, 740.426, 744.345, 751.064, 766.181, 782.419, 788.578, 794.737, 809.295, 813.774, 826.652, 841.209, 860.246],
         "br": [0.89, 0.971, 1.106, 1.059, 1.127, 1.133, 1.125, 1.157, 1.137, 1.155, 1.116, 1.139, 1.03, 1.179, 1.182, 1.143, 1.163, 1.088, 1.16, 1.084,
         1.201, 1.201, 1.087, 1.159, 1.018, 1.079, 0.881, 1.072, 1.13],
-        "albedo": 0.83, // albedo from Zelario's sheet
+        "albedo": 0.83, // albedo from zelario's sheet
     },
     //"(486958) Arrokoth|Howett2019": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
     //	"filters": "Hubble", "indices": {"F606W-F814W": 1.03}, "sun": true
@@ -414,7 +445,7 @@
         "filters": "New Horizons", "bands": ["blue", "red", "nir"], "br": [0.066, 0.090, 0.125], "sun": true, "albedo": true
     },
     "1I/ʻOumuamua|Jewitt2017": {"tags": ["featured", "solar_system", "extrasolar", "asteroid"],
-        "filters": "UBVRI", "indices": {"B-V": 0.70, "V-R": 0.45}, "sun": true, "albedo": 0.1
+        "filters": "Landolt", "indices": {"B-V": 0.70, "V-R": 0.45}, "sun": true, "albedo": 0.1
     },
     "1I/ʻOumuamua|Bannister2017": {"tags": ["solar_system", "extrasolar", "asteroid"],
         "filters": "Sloan Vacuum", "indices": {"g-r": 0.47, "r-i": 0.36}, "sun": true, "albedo": 0.07

--- a/spectra/07_SMASS_database.json5
+++ b/spectra/07_SMASS_database.json5
@@ -3,7 +3,7 @@
         "SMASS: Small Main-Belt Asteroid Spectroscopic Survey",
         "http://smass.mit.edu/smass.html"
     ],
-    "(1) Ceres|SMASS": {"tags": ["featured", "solar_system", "minor_body", "dwarf_planet", "asteroid", "main_belt"],
+    "(1) Ceres|SMASS": {"tags": ["featured", "solar_system", "planet-geophys", "minor_body", "dwarf_planet", "asteroid", "main_belt"],
         "nm": [435, 437.5, 440, 442.5, 445, 447.5, 450, 452.5, 455, 457.5, 460, 462.5, 465, 467.5, 470, 472.5, 475, 477.5, 480, 482.5, 485, 487.5, 490, 
         492.5, 495, 497.5, 500, 502.5, 505, 507.5, 510, 512.5, 515, 517.5, 520, 522.5, 525, 527.5, 530, 532.5, 535, 537.5, 540, 542.5, 545, 547.5, 550, 
         552.5, 555, 557.5, 560, 562.5, 565, 567.5, 570, 572.5, 575, 577.5, 580, 582.5, 585, 587.5, 590, 592.5, 595, 597.5, 600, 602.5, 605, 607.5, 610, 

--- a/spectra/08_MBOSS_database.json5
+++ b/spectra/08_MBOSS_database.json5
@@ -4,1266 +4,1266 @@
         "http://www.eso.org/~ohainaut/MBOSS/", "http://www.eso.org/~ohainaut/MBOSS/mbossClasses.txt"
     ],
     "C/1995O1-HB|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.390}, "sun": true
     },
     "C/1999J2|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.687, "V-R": 0.426, "R-I": 0.403}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.687, "V-R": 0.426, "R-I": 0.403}, "sun": true
     },
     "C/2001G1|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.752, "V-R": 0.430, "R-I": 0.433}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.752, "V-R": 0.430, "R-I": 0.433}, "sun": true
     },
     "C/2001M10|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.963, "V-R": 0.350, "R-I": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.963, "V-R": 0.350, "R-I": 0.520}, "sun": true
     },
     "C/2002CE10-LINEA|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.542, "R-I": 0.504}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.542, "R-I": 0.504}, "sun": true
     },
     "C/2002VQ94-LINEA|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.500, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.500, "R-I": 0.480}, "sun": true
     },
     "C/2003A2-Gleason|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.610, "V-R": 0.470, "R-I": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.610, "V-R": 0.470, "R-I": 0.460}, "sun": true
     },
     "C/2004D1-NEAT|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.430, "R-I": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.430, "R-I": 0.510}, "sun": true
     },
     "C/2006S3-Loneos|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.580}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.580}, "sun": true
     },
     "C/2007D1-LINEAR|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.440, "R-I": 0.410}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.440, "R-I": 0.410}, "sun": true
     },
     "C/2008S3-Boattin|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.769, "V-R": 0.448, "R-I": 0.364}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.769, "V-R": 0.448, "R-I": 0.364}, "sun": true
     },
     "C/2009T1-McNaugh|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.640, "V-R": 0.530, "R-I": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.640, "V-R": 0.530, "R-I": 0.450}, "sun": true
     },
     "C/2010D4-WISE|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.460}, "sun": true
     },
     "C/2010DG56-WISE|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.370}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.370}, "sun": true
     },
     "C/2010L3-Catalin|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.420, "R-I": 0.410}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.420, "R-I": 0.410}, "sun": true
     },
     "C/2010U3-Boattin|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.778, "V-R": 0.520, "R-I": 0.320}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.778, "V-R": 0.520, "R-I": 0.320}, "sun": true
     },
     "C/2011P2-PANSTAR|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.919, "V-R": 0.323}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.919, "V-R": 0.323}, "sun": true
     },
     "C/2011Q1-PANSTAR|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.819, "V-R": 0.489}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.819, "V-R": 0.489}, "sun": true
     },
     "C/2012A1-PANSTAR|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.450}, "sun": true
     },
     "C/2012E1-Hill|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.400}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.400}, "sun": true
     },
     "C/2012LP26-Palom|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.854, "V-R": 0.516}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.854, "V-R": 0.516}, "sun": true
     },
     "C/2012Q1-Kowalsk|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.907, "V-R": 0.537}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.907, "V-R": 0.537}, "sun": true
     },
     "C/2013C2|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.887, "V-R": 0.533}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.887, "V-R": 0.533}, "sun": true
     },
     "C/2013E1-McNaugh|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.480}, "sun": true
     },
     "C/2013H2-Boattin|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.490}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.490}, "sun": true
     },
     "C/2013P3-Palomar|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.450}, "sun": true
     },
     "C/2013P4|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.827, "V-R": 0.487}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.827, "V-R": 0.487}, "sun": true
     },
     "C/2014AA52-CATAL|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.410}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.410}, "sun": true
     },
     "C/2014B1-Schwarz|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.580}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.580}, "sun": true
     },
     "C/2014R1-Borisov|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.460}, "sun": true
     },
     "C/2014W6-Catalin|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.450}, "sun": true
     },
     "C/2014XB8-PANSTA|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.440}, "sun": true
     },
     "C/2015B1-PANSTAR|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-lp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.780, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.780, "V-R": 0.450}, "sun": true
     },
     "P/2011S1-Gibbs|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.960, "V-R": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.960, "V-R": 0.590}, "sun": true
     },
     "1P/Halley|MBOSS": {"tags": ["featured", "solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.410, "R-I": 0.390}, "sun": true, "albedo": 0.04
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.410, "R-I": 0.390}, "sun": true, "albedo": 0.04
     },
     "2P/Encke|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.780, "V-R": 0.424, "R-I": 0.408}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.780, "V-R": 0.424, "R-I": 0.408}, "sun": true
     },
     "6P/dArrest|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.563, "R-I": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.563, "R-I": 0.450}, "sun": true
     },
     "8P/Tuttle|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.890, "V-R": 0.530, "R-I": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.890, "V-R": 0.530, "R-I": 0.530}, "sun": true
     },
     "10P/Tempel2|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.800, "V-R": 0.521, "R-I": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.800, "V-R": 0.521, "R-I": 0.520}, "sun": true
     },
     "21P/GZ|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.800, "V-R": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.800, "V-R": 0.500}, "sun": true
     },
     "22P/Kopff|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.795, "V-R": 0.519, "R-I": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.795, "V-R": 0.519, "R-I": 0.450}, "sun": true
     },
     "39P/Oterma|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.890, "V-R": 0.386, "R-I": 0.412}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.890, "V-R": 0.386, "R-I": 0.412}, "sun": true
     },
     "45P/HMP|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 1.080, "V-R": 0.440, "R-I": 0.210}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.080, "V-R": 0.440, "R-I": 0.210}, "sun": true
     },
     "47P/AJ|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.780, "V-R": 0.400}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.780, "V-R": 0.400}, "sun": true
     },
     "49P/AR|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.471, "R-I": 0.444}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.471, "R-I": 0.444}, "sun": true
     },
     "55P/TT|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.510, "R-I": 0.420}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.510, "R-I": 0.420}, "sun": true
     },
     "86P/Wild3|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 1.580, "V-R": 0.555}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.580, "V-R": 0.555}, "sun": true
     },
     "106P/Schuster|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 1.010, "V-R": 0.520, "R-I": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.010, "V-R": 0.520, "R-I": 0.450}, "sun": true
     },
     "107P/WH|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.674, "V-R": 0.361}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.674, "V-R": 0.361}, "sun": true
     },
     "114P/WS|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.460, "R-I": 0.540}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.460, "R-I": 0.540}, "sun": true
     },
     "143P/KM|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.580, "R-I": 0.560}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.580, "R-I": 0.560}, "sun": true
     },
     "166P/2001T4|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.870, "V-R": 0.695, "R-I": 0.735}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.870, "V-R": 0.695, "R-I": 0.735}, "sun": true
     },
     "166P/NEAT|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.890, "V-R": 0.560}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.890, "V-R": 0.560}, "sun": true
     },
     "167P/CINEOS|MBOSS": {"tags": ["solar_system", "minor_body", "comet", "comet-sp"],
-        "filters": "UBVRI", "indices": {"B-V": 0.758, "V-R": 0.516, "R-I": 0.504}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.758, "V-R": 0.516, "R-I": 0.504}, "sun": true
     },
     "1994 EV3|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.065, "V-R": 0.588, "R-I": 0.800}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.065, "V-R": 0.588, "R-I": 0.800}, "sun": true
     },
     "1994 TA|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.261, "V-R": 0.672, "R-I": 0.740}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.261, "V-R": 0.672, "R-I": 0.740}, "sun": true
     },
     "1995 HM5|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.649, "V-R": 0.460, "R-I": 0.428}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.649, "V-R": 0.460, "R-I": 0.428}, "sun": true
     },
     "1996 RQ20|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.935, "V-R": 0.558, "R-I": 0.591}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.935, "V-R": 0.558, "R-I": 0.591}, "sun": true
     },
     "1996 RR20|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.143, "V-R": 0.730, "R-I": 0.628}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.143, "V-R": 0.730, "R-I": 0.628}, "sun": true
     },
     "1996 TK66|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.993, "V-R": 0.680, "R-I": 0.551}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.993, "V-R": 0.680, "R-I": 0.551}, "sun": true
     },
     "1996 TS66|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.028, "V-R": 0.672, "R-I": 0.637}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.028, "V-R": 0.672, "R-I": 0.637}, "sun": true
     },
     "1997 QH4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.088, "V-R": 0.641, "R-I": 0.631}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.088, "V-R": 0.641, "R-I": 0.631}, "sun": true
     },
     "1998 FS144|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.950, "V-R": 0.588, "R-I": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.950, "V-R": 0.588, "R-I": 0.510}, "sun": true
     },
     "1998 KS65|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.090, "V-R": 0.640}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.090, "V-R": 0.640}, "sun": true
     },
     "1998 UR43|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.784, "V-R": 0.583, "R-I": 0.354}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.784, "V-R": 0.583, "R-I": 0.354}, "sun": true
     },
     "1998 WS31|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.726, "V-R": 0.606, "R-I": 0.439}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.726, "V-R": 0.606, "R-I": 0.439}, "sun": true
     },
     "1998 WU24|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.780, "V-R": 0.530, "R-I": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.780, "V-R": 0.530, "R-I": 0.460}, "sun": true
     },
     "1998 WV24|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.502, "R-I": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.502, "R-I": 0.450}, "sun": true
     },
     "1998 WV31|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.521, "R-I": 0.481}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.521, "R-I": 0.481}, "sun": true
     },
     "1998 WX24|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.090, "V-R": 0.727, "R-I": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.090, "V-R": 0.727, "R-I": 0.500}, "sun": true
     },
     "1998 WZ31|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.727, "V-R": 0.489, "R-I": 0.339}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.727, "V-R": 0.489, "R-I": 0.339}, "sun": true
     },
     "1999 CB119|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.212, "V-R": 0.714, "R-I": 0.645}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.212, "V-R": 0.714, "R-I": 0.645}, "sun": true
     },
     "1999 CX131|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.918, "V-R": 0.664, "R-I": 0.434}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.918, "V-R": 0.664, "R-I": 0.434}, "sun": true
     },
     "1999 HS11|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.121, "V-R": 0.698, "R-I": 0.600}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.121, "V-R": 0.698, "R-I": 0.600}, "sun": true
     },
     "1999 HV11|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.110, "V-R": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.110, "V-R": 0.590}, "sun": true
     },
     "1999 LE31|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.748, "V-R": 0.467, "R-I": 0.521}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.748, "V-R": 0.467, "R-I": 0.521}, "sun": true
     },
     "1999 OJ4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.098, "V-R": 0.668, "R-I": 0.549}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.098, "V-R": 0.668, "R-I": 0.549}, "sun": true
     },
     "1999 RX214|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.054, "V-R": 0.593, "R-I": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.054, "V-R": 0.593, "R-I": 0.530}, "sun": true
     },
     "1999 TR11|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.020, "V-R": 0.750, "R-I": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.020, "V-R": 0.750, "R-I": 0.650}, "sun": true
     },
     "2000 CL104|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.223, "V-R": 0.600, "R-I": 0.612}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.223, "V-R": 0.600, "R-I": 0.612}, "sun": true
     },
     "2000 FS53|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.060, "V-R": 0.710}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.060, "V-R": 0.710}, "sun": true
     },
     "2000 HE46|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.870, "V-R": 0.550, "R-I": 0.400}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.870, "V-R": 0.550, "R-I": 0.400}, "sun": true
     },
     "2000 KK4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.910, "V-R": 0.580, "R-I": 0.640}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.910, "V-R": 0.580, "R-I": 0.640}, "sun": true
     },
     "2001 FM194|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.760, "V-R": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.760, "V-R": 0.440}, "sun": true
     },
     "2001 KA77|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.104, "V-R": 0.704, "R-I": 0.716}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.104, "V-R": 0.704, "R-I": 0.716}, "sun": true
     },
     "2001 KD77|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.123, "V-R": 0.624, "R-I": 0.565}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.123, "V-R": 0.624, "R-I": 0.565}, "sun": true
     },
     "2001 KG77|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.440}, "sun": true
     },
     "2001 QC298|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.490, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.490, "R-I": 0.480}, "sun": true
     },
     "2001 QR322|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.800, "V-R": 0.460, "R-I": 0.360}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.800, "V-R": 0.460, "R-I": 0.360}, "sun": true
     },
     "2001 QX322|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.914, "V-R": 0.562}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.914, "V-R": 0.562}, "sun": true
     },
     "2001 XZ255|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.224, "V-R": 0.709}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.224, "V-R": 0.709}, "sun": true
     },
     "2002 GH32|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.990, "V-R": 0.570, "R-I": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.990, "V-R": 0.570, "R-I": 0.590}, "sun": true
     },
     "2002 PQ152|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.130, "V-R": 0.720}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.130, "V-R": 0.720}, "sun": true
     },
     "2002 XV93|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.375}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.375}, "sun": true
     },
     "2003 FZ129|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.840, "V-R": 0.480, "R-I": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.840, "V-R": 0.480, "R-I": 0.460}, "sun": true
     },
     "2003 QA92|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.040, "V-R": 0.630}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.040, "V-R": 0.630}, "sun": true
     },
     "2003 QK91|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.870, "V-R": 0.500, "R-I": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.870, "V-R": 0.500, "R-I": 0.470}, "sun": true
     },
     "2003 QQ91|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.670, "V-R": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.670, "V-R": 0.510}, "sun": true
     },
     "2003 UY291|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.880, "V-R": 0.510, "R-I": 0.670}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.880, "V-R": 0.510, "R-I": 0.670}, "sun": true
     },
     "2003 WN188|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.780, "V-R": 0.480, "R-I": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.780, "V-R": 0.480, "R-I": 0.500}, "sun": true
     },
     "2004 DA62|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.520, "R-I": 0.550}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.520, "R-I": 0.550}, "sun": true
     },
     "2004 OJ14|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.900, "V-R": 0.520, "R-I": 0.540}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.900, "V-R": 0.520, "R-I": 0.540}, "sun": true
     },
     "2004 XR190|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.450, "R-I": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.450, "R-I": 0.520}, "sun": true
     },
     "2005 TN53|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.470}, "sun": true
     },
     "2006 RJ103|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.270}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.270}, "sun": true
     },
     "2007 VH305|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.690, "V-R": 0.491, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.690, "V-R": 0.491, "R-I": 0.480}, "sun": true
     },
     "2009 YG19|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.000, "V-R": 0.610}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.000, "V-R": 0.610}, "sun": true
     },
     "2010 BK118|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.794, "V-R": 0.525, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.794, "V-R": 0.525, "R-I": 0.480}, "sun": true
     },
     "2010 BL4|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.860, "V-R": 0.390, "R-I": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.860, "V-R": 0.390, "R-I": 0.470}, "sun": true
     },
     "2010 OM101|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.795, "V-R": 0.588, "R-I": 0.360}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.795, "V-R": 0.588, "R-I": 0.360}, "sun": true
     },
     "2010 OR1|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.781, "V-R": 0.517, "R-I": 0.447}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.781, "V-R": 0.517, "R-I": 0.447}, "sun": true
     },
     "2010 TS191|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.760, "V-R": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.760, "V-R": 0.390}, "sun": true
     },
     "2010 TT191|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.470}, "sun": true
     },
     "2010 WG9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.781, "V-R": 0.492, "R-I": 0.458}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.781, "V-R": 0.492, "R-I": 0.458}, "sun": true
     },
     "2011 HM102|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.410, "R-I": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.410, "R-I": 0.520}, "sun": true
     },
     "2012 DR30|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.647, "V-R": 0.563, "R-I": 0.422}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.647, "V-R": 0.563, "R-I": 0.422}, "sun": true
     },
     "2012 VP113|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.520, "R-I": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.520, "R-I": 0.530}, "sun": true
     },
     "2013 AZ60|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.540}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.540}, "sun": true
     },
     "2013 BL76|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.450}, "sun": true
     },
     "2013 BO16|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 1.140, "V-R": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.140, "V-R": 0.650}, "sun": true
     },
     "2013 CX217|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.280}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.280}, "sun": true
     },
     "2013 CY197|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.880, "V-R": 0.510, "R-I": 0.610}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.880, "V-R": 0.510, "R-I": 0.610}, "sun": true
     },
     "2013 KY18|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.760, "V-R": 0.360}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.760, "V-R": 0.360}, "sun": true
     },
     "2013 LD16|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.860, "V-R": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.860, "V-R": 0.440}, "sun": true
     },
     "2013 NS11|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.560}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.560}, "sun": true
     },
     "2013 TZ158|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.536, "R-I": 0.497}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.536, "R-I": 0.497}, "sun": true
     },
     "2013 YG48|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.800, "V-R": 0.515}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.800, "V-R": 0.515}, "sun": true
     },
     "2014 CW14|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.870, "V-R": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.870, "V-R": 0.510}, "sun": true
     },
     "2014 QO441|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.470}, "sun": true
     },
     "(1172) Aneas|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.727, "V-R": 0.510, "R-I": 0.400}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.727, "V-R": 0.510, "R-I": 0.400}, "sun": true
     },
     "(1173) Anchises|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.811, "V-R": 0.402, "R-I": 0.403}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.811, "V-R": 0.402, "R-I": 0.403}, "sun": true
     },
     "(1871) Astyanax|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.716, "V-R": 0.456, "R-I": 0.424}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.716, "V-R": 0.456, "R-I": 0.424}, "sun": true
     },
     "(2060) Chiron|MBOSS": {"tags": ["featured", "solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.660, "V-R": 0.359, "R-I": 0.324}, "sun": true, "albedo": 0.16
+        "filters": "Landolt", "indices": {"B-V": 0.660, "V-R": 0.359, "R-I": 0.324}, "sun": true, "albedo": 0.16
     },
     "(2223) Sarpedon|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.753, "V-R": 0.465, "R-I": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.753, "V-R": 0.465, "R-I": 0.440}, "sun": true
     },
     "(2357) Phereclos|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.718, "V-R": 0.427, "R-I": 0.463}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.718, "V-R": 0.427, "R-I": 0.463}, "sun": true
     },
     "(3548) Eurybates|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.677, "V-R": 0.352, "R-I": 0.339}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.677, "V-R": 0.352, "R-I": 0.339}, "sun": true
     },
     "(4035) 1986 WD|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.752, "V-R": 0.484, "R-I": 0.451}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.752, "V-R": 0.484, "R-I": 0.451}, "sun": true
     },
     "(4829) Sergestus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.851, "V-R": 0.420, "R-I": 0.372}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.851, "V-R": 0.420, "R-I": 0.372}, "sun": true
     },
     "(5130) Ilioneus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.763, "V-R": 0.481, "R-I": 0.424}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.763, "V-R": 0.481, "R-I": 0.424}, "sun": true
     },
     "(5145) Pholus|MBOSS": {"tags": ["featured", "solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.261, "V-R": 0.791, "R-I": 0.818}, "sun": true, "albedo": 0.155
+        "filters": "Landolt", "indices": {"B-V": 1.261, "V-R": 0.791, "R-I": 0.818}, "sun": true, "albedo": 0.155
     },
     "(5511) Cloanthus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.906, "V-R": 0.442, "R-I": 0.526}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.906, "V-R": 0.442, "R-I": 0.526}, "sun": true
     },
     "(6545) 1986 TR6|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.734, "V-R": 0.499, "R-I": 0.436}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.734, "V-R": 0.499, "R-I": 0.436}, "sun": true
     },
     "(6998) Tithonus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.787, "V-R": 0.455, "R-I": 0.438}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.787, "V-R": 0.455, "R-I": 0.438}, "sun": true
     },
     "(7066) Nessus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.090, "V-R": 0.763, "R-I": 0.689}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.090, "V-R": 0.763, "R-I": 0.689}, "sun": true
     },
     "(7352) 1994 CO|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.713, "V-R": 0.417, "R-I": 0.397}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.713, "V-R": 0.417, "R-I": 0.397}, "sun": true
     },
     "(8405) Asbolus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.738, "V-R": 0.508, "R-I": 0.505}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.738, "V-R": 0.508, "R-I": 0.505}, "sun": true
     },
     "(9030) 1989 UX5|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.887, "V-R": 0.493, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.887, "V-R": 0.493, "R-I": 0.480}, "sun": true
     },
     "(9430) Erichthonio|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.742, "V-R": 0.488, "R-I": 0.456}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.742, "V-R": 0.488, "R-I": 0.456}, "sun": true
     },
     "(9818) Eurymachos|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.673, "V-R": 0.339, "R-I": 0.355}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.673, "V-R": 0.339, "R-I": 0.355}, "sun": true
     },
     "(10199) Chariklo|MBOSS": {"tags": ["featured", "solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.802, "V-R": 0.491, "R-I": 0.519}, "sun": true, "albedo": 0.035
+        "filters": "Landolt", "indices": {"B-V": 0.802, "V-R": 0.491, "R-I": 0.519}, "sun": true, "albedo": 0.035
     }, // albedo from https://arxiv.org/abs/1409.7259
     "(10370) Hylonome|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.690, "V-R": 0.469, "R-I": 0.496}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.690, "V-R": 0.469, "R-I": 0.496}, "sun": true
     },
     "(11089) 1994 CS8|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.689, "V-R": 0.423, "R-I": 0.384}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.689, "V-R": 0.423, "R-I": 0.384}, "sun": true
     },
     "(11351) Leucus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.739, "V-R": 0.498, "R-I": 0.402}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.739, "V-R": 0.498, "R-I": 0.402}, "sun": true
     },
     "(11488) 1988 RM11|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.777, "V-R": 0.436, "R-I": 0.420}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.777, "V-R": 0.436, "R-I": 0.420}, "sun": true
     },
     "(11663) 1997 GO24|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.837, "V-R": 0.409, "R-I": 0.463}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.837, "V-R": 0.409, "R-I": 0.463}, "sun": true
     },
     "(12917) 1998 TG16|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.724, "V-R": 0.537, "R-I": 0.410}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.724, "V-R": 0.537, "R-I": 0.410}, "sun": true
     },
     "(12921) 1998 WZ5|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.673, "V-R": 0.403, "R-I": 0.380}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.673, "V-R": 0.403, "R-I": 0.380}, "sun": true
     },
     "(13463) Antiphos|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.692, "V-R": 0.449, "R-I": 0.412}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.692, "V-R": 0.449, "R-I": 0.412}, "sun": true
     },
     "(14707) 2000 CC20|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.752, "V-R": 0.412, "R-I": 0.385}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.752, "V-R": 0.412, "R-I": 0.385}, "sun": true
     },
     "(15094) Polymele|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.652, "V-R": 0.477, "R-I": 0.322}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.652, "V-R": 0.477, "R-I": 0.322}, "sun": true
     },
     "(15502) 1999 NV27|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.766, "V-R": 0.445, "R-I": 0.430}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.766, "V-R": 0.445, "R-I": 0.430}, "sun": true
     },
     "(15504) 1999 RG33|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.817, "V-R": 0.495, "R-I": 0.350}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.817, "V-R": 0.495, "R-I": 0.350}, "sun": true
     },
     "(15535) 2000 AT177|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.739, "V-R": 0.470, "R-I": 0.461}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.739, "V-R": 0.470, "R-I": 0.461}, "sun": true
     },
     "(15760) Albion|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.869, "V-R": 0.707, "R-I": 0.651}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.869, "V-R": 0.707, "R-I": 0.651}, "sun": true
     },
     "(15788) 1993 SB|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.802, "V-R": 0.475, "R-I": 0.514}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.802, "V-R": 0.475, "R-I": 0.514}, "sun": true
     },
     "(15789) 1993 SC|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.045, "V-R": 0.688, "R-I": 0.697}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.045, "V-R": 0.688, "R-I": 0.697}, "sun": true
     },
     "(15810) Arawn|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.010, "V-R": 0.632, "R-I": 0.538}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.010, "V-R": 0.632, "R-I": 0.538}, "sun": true
     },
     "(15820) 1994 TB|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.107, "V-R": 0.697, "R-I": 0.739}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.107, "V-R": 0.697, "R-I": 0.739}, "sun": true
     },
     "(15874) 1996 TL66|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.687, "V-R": 0.369, "R-I": 0.370}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.687, "V-R": 0.369, "R-I": 0.370}, "sun": true
     },
     "(15875) 1996 TP66|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.031, "V-R": 0.655, "R-I": 0.673}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.031, "V-R": 0.655, "R-I": 0.673}, "sun": true
     },
     "(15883) 1997 CR29|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.538, "R-I": 0.620}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.538, "R-I": 0.620}, "sun": true
     },
     "(15977) 1998 MA11|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.748, "V-R": 0.465, "R-I": 0.441}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.748, "V-R": 0.465, "R-I": 0.441}, "sun": true
     },
     "(16684) 1994 JQ1|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.134, "V-R": 0.736, "R-I": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.134, "V-R": 0.736, "R-I": 0.650}, "sun": true
     },
     "(17416) 1988 RR10|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.742, "V-R": 0.488, "R-I": 0.498}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.742, "V-R": 0.488, "R-I": 0.498}, "sun": true
     },
     "(18060) 1999 XJ156|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.758, "V-R": 0.412, "R-I": 0.364}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.758, "V-R": 0.412, "R-I": 0.364}, "sun": true
     },
     "(18137) 2000 OU30|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.733, "V-R": 0.496, "R-I": 0.409}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.733, "V-R": 0.496, "R-I": 0.409}, "sun": true
     },
     "(18268) Dardanos|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.795, "V-R": 0.529, "R-I": 0.451}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.795, "V-R": 0.529, "R-I": 0.451}, "sun": true
     },
     "(18493) Demoleon|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.703, "V-R": 0.395, "R-I": 0.380}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.703, "V-R": 0.395, "R-I": 0.380}, "sun": true
     },
     "(18940) 2000 QV49|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.709, "V-R": 0.465, "R-I": 0.429}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.709, "V-R": 0.465, "R-I": 0.429}, "sun": true
     },
     "(19255) 1994 VK8|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.010, "V-R": 0.659, "R-I": 0.490}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.010, "V-R": 0.659, "R-I": 0.490}, "sun": true
     },
     "(19299) 1996 SZ4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.754, "V-R": 0.522, "R-I": 0.446}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.754, "V-R": 0.522, "R-I": 0.446}, "sun": true
     },
     "(19308) 1996 TO66|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.671, "V-R": 0.389, "R-I": 0.356}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.671, "V-R": 0.389, "R-I": 0.356}, "sun": true
     },
     "(19521) Chaos|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.932, "V-R": 0.608, "R-I": 0.571}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.932, "V-R": 0.608, "R-I": 0.571}, "sun": true
     },
     "(20000) Varuna|MBOSS": {"tags": ["featured", "solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.906, "V-R": 0.626, "R-I": 0.628}, "sun": true, "albedo": 0.172
+        "filters": "Landolt", "indices": {"B-V": 0.906, "V-R": 0.626, "R-I": 0.628}, "sun": true, "albedo": 0.172
     }, // albedo from fyr02's sheet
     "(20108) 1995 QZ9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.880, "V-R": 0.515}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.880, "V-R": 0.515}, "sun": true
     },
     "(20738) 1999 XG191|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.776, "V-R": 0.472, "R-I": 0.467}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.776, "V-R": 0.472, "R-I": 0.467}, "sun": true
     },
     "(23549) Epicles|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.800, "V-R": 0.485, "R-I": 0.387}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.800, "V-R": 0.485, "R-I": 0.387}, "sun": true
     },
     "(23694) 1997 KZ3|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.723, "V-R": 0.474, "R-I": 0.418}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.723, "V-R": 0.474, "R-I": 0.418}, "sun": true
     },
     "(24233) 1999 XD94|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.704, "V-R": 0.481, "R-I": 0.418}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.704, "V-R": 0.481, "R-I": 0.418}, "sun": true
     },
     "(24341) 2000 AJ87|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.713, "V-R": 0.369, "R-I": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.713, "V-R": 0.369, "R-I": 0.390}, "sun": true
     },
     "(24380) 2000 AA160|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.734, "V-R": 0.391, "R-I": 0.336}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.734, "V-R": 0.391, "R-I": 0.336}, "sun": true
     },
     "(24390) 2000 AD177|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.700, "V-R": 0.513, "R-I": 0.462}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.700, "V-R": 0.513, "R-I": 0.462}, "sun": true
     },
     "(24420) 2000 BU22|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.937, "V-R": 0.441, "R-I": 0.304}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.937, "V-R": 0.441, "R-I": 0.304}, "sun": true
     },
     "(24426) 2000 CR12|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.717, "V-R": 0.414, "R-I": 0.424}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.717, "V-R": 0.414, "R-I": 0.424}, "sun": true
     },
     "(24444) 2000 OP32|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.712, "V-R": 0.437, "R-I": 0.409}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.712, "V-R": 0.437, "R-I": 0.409}, "sun": true
     },
     "(24452) 2000 QU167|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.872, "V-R": 0.441, "R-I": 0.406}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.872, "V-R": 0.441, "R-I": 0.406}, "sun": true
     },
     "(24467) 2000 SS165|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.927, "V-R": 0.460, "R-I": 0.513}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.927, "V-R": 0.460, "R-I": 0.513}, "sun": true
     },
     "(24835) 1995 SM55|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.652, "V-R": 0.357, "R-I": 0.356}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.652, "V-R": 0.357, "R-I": 0.356}, "sun": true
     },
     "(24952) 1997 QJ4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.763, "V-R": 0.431, "R-I": 0.396}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.763, "V-R": 0.431, "R-I": 0.396}, "sun": true
     },
     "(24978) 1998 HJ151|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.110, "V-R": 0.710}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.110, "V-R": 0.710}, "sun": true
     },
     "(25347) 1999 RQ116|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.618, "V-R": 0.488, "R-I": 0.461}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.618, "V-R": 0.488, "R-I": 0.461}, "sun": true
     },
     "(26181) 1996 GQ21|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.999, "V-R": 0.697, "R-I": 0.694}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.999, "V-R": 0.697, "R-I": 0.694}, "sun": true
     },
     "(26308) 1998 SM165|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.989, "V-R": 0.641, "R-I": 0.666}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.989, "V-R": 0.641, "R-I": 0.666}, "sun": true
     },
     "(26375) 1999 DE9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.967, "V-R": 0.579, "R-I": 0.568}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.967, "V-R": 0.579, "R-I": 0.568}, "sun": true
     },
     "(28958) 2001 CQ42|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.730, "V-R": 0.364, "R-I": 0.230}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.730, "V-R": 0.364, "R-I": 0.230}, "sun": true
     },
     "(28978) Ixion|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.018, "V-R": 0.605, "R-I": 0.580}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.018, "V-R": 0.605, "R-I": 0.580}, "sun": true
     },
     "(29981) 1999 TD10|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.808, "V-R": 0.502, "R-I": 0.511}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.808, "V-R": 0.502, "R-I": 0.511}, "sun": true
     },
     "(30698) Hippokoon|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.715, "V-R": 0.458, "R-I": 0.412}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.715, "V-R": 0.458, "R-I": 0.412}, "sun": true
     },
     "(31820) 1999 RT186|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.889, "V-R": 0.520, "R-I": 0.396}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.889, "V-R": 0.520, "R-I": 0.396}, "sun": true
     },
     "(31821) 1999 RK225|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.980, "V-R": 0.440, "R-I": 0.461}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.980, "V-R": 0.440, "R-I": 0.461}, "sun": true
     },
     "(31824) Elatus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.020, "V-R": 0.620, "R-I": 0.630}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.020, "V-R": 0.620, "R-I": 0.630}, "sun": true
     },
     "(32430) 2000 RQ83|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.772, "V-R": 0.474, "R-I": 0.425}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.772, "V-R": 0.474, "R-I": 0.425}, "sun": true
     },
     "(32532) Thereus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.764, "V-R": 0.501, "R-I": 0.479}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.764, "V-R": 0.501, "R-I": 0.479}, "sun": true
     },
     "(32615) 2001 QU277|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.807, "V-R": 0.452, "R-I": 0.474}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.807, "V-R": 0.452, "R-I": 0.474}, "sun": true
     },
     "(32794) 1989 UE5|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.923, "V-R": 0.393, "R-I": 0.486}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.923, "V-R": 0.393, "R-I": 0.486}, "sun": true
     },
     "(32929) 1995 QY9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.561}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.561}, "sun": true
     },
     "(33001) 1997 CU29|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.157, "V-R": 0.645, "R-I": 0.634}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.157, "V-R": 0.645, "R-I": 0.634}, "sun": true
     },
     "(33128) 1998 BU48|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.044, "V-R": 0.631, "R-I": 0.644}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.044, "V-R": 0.631, "R-I": 0.644}, "sun": true
     },
     "(33340) 1998 VG44|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.955, "V-R": 0.555, "R-I": 0.598}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.955, "V-R": 0.555, "R-I": 0.598}, "sun": true
     },
     "(34785) 2001 RG87|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.728, "V-R": 0.386, "R-I": 0.419}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.728, "V-R": 0.386, "R-I": 0.419}, "sun": true
     },
     "(35671) 1998 SN165|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.712, "V-R": 0.444, "R-I": 0.437}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.712, "V-R": 0.444, "R-I": 0.437}, "sun": true
     },
     "(38083) Rhadamanth|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.650, "V-R": 0.527, "R-I": 0.412}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.650, "V-R": 0.527, "R-I": 0.412}, "sun": true
     },
     "(38084) 1999 HB12|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.893, "V-R": 0.544, "R-I": 0.481}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.893, "V-R": 0.544, "R-I": 0.481}, "sun": true
     },
     "(38628) Huya|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.963, "V-R": 0.609, "R-I": 0.593}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.963, "V-R": 0.609, "R-I": 0.593}, "sun": true
     },
     "(39285) 2001 BP75|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.381, "R-I": 0.291}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.381, "R-I": 0.291}, "sun": true
     },
     "(40314) 1999 KR16|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.123, "V-R": 0.738, "R-I": 0.750}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.123, "V-R": 0.738, "R-I": 0.750}, "sun": true
     },
     "(42301) 2001 UR163|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 1.290, "V-R": 0.839, "R-I": 0.673}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.290, "V-R": 0.839, "R-I": 0.673}, "sun": true
     },
     "(42355) Typhon|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.758, "V-R": 0.518, "R-I": 0.378}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.758, "V-R": 0.518, "R-I": 0.378}, "sun": true
     },
     "(44594) 1999 OX3|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.138, "V-R": 0.708, "R-I": 0.640}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.138, "V-R": 0.708, "R-I": 0.640}, "sun": true
     },
     "(47171) Lempo|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.029, "V-R": 0.693, "R-I": 0.619}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.029, "V-R": 0.693, "R-I": 0.619}, "sun": true
     },
     "(47932) 2000 GN171|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.960, "V-R": 0.607, "R-I": 0.617}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.960, "V-R": 0.607, "R-I": 0.617}, "sun": true
     },
     "(47967) 2000 SL298|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.899, "V-R": 0.489, "R-I": 0.476}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.899, "V-R": 0.489, "R-I": 0.476}, "sun": true
     },
     "(48249) 2001 SY345|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.758, "V-R": 0.530, "R-I": 0.420}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.758, "V-R": 0.530, "R-I": 0.420}, "sun": true
     },
     "(48252) 2001 TL212|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.949, "V-R": 0.467, "R-I": 0.436}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.949, "V-R": 0.467, "R-I": 0.436}, "sun": true
     },
     "(48639) 1995 TL8|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.008, "V-R": 0.621, "R-I": 0.551}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.008, "V-R": 0.621, "R-I": 0.551}, "sun": true
     },
     "(49036) Pelion|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.746, "V-R": 0.556, "R-I": 0.368}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.746, "V-R": 0.556, "R-I": 0.368}, "sun": true
     },
-    "(50000) Quaoar|MBOSS": {"tags": ["featured", "solar_system", "minor_body", "dwarf_planet", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.958, "V-R": 0.650, "R-I": 0.610}, "sun": true, "albedo": 0.109
+    "(50000) Quaoar|MBOSS": {"tags": ["featured", "solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "classical", "classical-h"],
+        "filters": "Landolt", "indices": {"B-V": 0.958, "V-R": 0.650, "R-I": 0.610}, "sun": true, "albedo": 0.109
     }, // albedo from fyr02's sheet
     "(51359) 2000 SC17|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.864, "V-R": 0.447, "R-I": 0.438}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.864, "V-R": 0.447, "R-I": 0.438}, "sun": true
     },
     "(52747) 1998 HM151|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.930, "V-R": 0.620}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.930, "V-R": 0.620}, "sun": true
     },
     "(52872) Okyrhoe|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.743, "V-R": 0.495, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.743, "V-R": 0.495, "R-I": 0.480}, "sun": true
     },
     "(52975) Cyllarus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.096, "V-R": 0.680, "R-I": 0.669}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.096, "V-R": 0.680, "R-I": 0.669}, "sun": true
     },
     "(53469) 2000 AX8|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.663, "V-R": 0.356, "R-I": 0.361}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.663, "V-R": 0.356, "R-I": 0.361}, "sun": true
     },
     "(54598) Bienor|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.711, "V-R": 0.476, "R-I": 0.400}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.711, "V-R": 0.476, "R-I": 0.400}, "sun": true
     },
     "(55565) 2002 AW197|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.915, "V-R": 0.589, "R-I": 0.581}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.915, "V-R": 0.589, "R-I": 0.581}, "sun": true
     },
     "(55576) Amycus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.111, "V-R": 0.705, "R-I": 0.666}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.111, "V-R": 0.705, "R-I": 0.666}, "sun": true
     },
     "(55636) 2002 TX300|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.679, "V-R": 0.359, "R-I": 0.323}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.679, "V-R": 0.359, "R-I": 0.323}, "sun": true
     },
     "(55637) 2002 UX25|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.979, "V-R": 0.552}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.979, "V-R": 0.552}, "sun": true
     },
     "(55638) 2002 VE95|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.094, "V-R": 0.733, "R-I": 0.760}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.094, "V-R": 0.733, "R-I": 0.760}, "sun": true
     },
     "(56968) 2000 SA92|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.986, "V-R": 0.494, "R-I": 0.509}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.986, "V-R": 0.494, "R-I": 0.509}, "sun": true
     },
     "(58534) Logos|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.990, "V-R": 0.729, "R-I": 0.602}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.990, "V-R": 0.729, "R-I": 0.602}, "sun": true
     },
     "(59358) 1999 CL158|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.800, "V-R": 0.390, "R-I": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.800, "V-R": 0.390, "R-I": 0.470}, "sun": true
     },
     "(60454) 2000 CH105|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.019, "V-R": 0.643, "R-I": 0.583}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.019, "V-R": 0.643, "R-I": 0.583}, "sun": true
     },
     "(60458) 2000 CM114|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.730, "V-R": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.730, "V-R": 0.500}, "sun": true
     },
     "(60558) Echeclus|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.841, "V-R": 0.502, "R-I": 0.486}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.841, "V-R": 0.502, "R-I": 0.486}, "sun": true
     },
     "(60608) 2000 EE173|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.665, "V-R": 0.488, "R-I": 0.543}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.665, "V-R": 0.488, "R-I": 0.543}, "sun": true
     },
     "(60620) 2000 FD8|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 1.151, "V-R": 0.664, "R-I": 0.648}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.151, "V-R": 0.664, "R-I": 0.648}, "sun": true
     },
     "(60621) 2000 FE8|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.750, "V-R": 0.480, "R-I": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.750, "V-R": 0.480, "R-I": 0.500}, "sun": true
     },
     "(63252) 2001 BL41|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.718, "V-R": 0.509, "R-I": 0.381}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.718, "V-R": 0.509, "R-I": 0.381}, "sun": true
     },
     "(65150) 2002 CA126|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.651, "V-R": 0.377, "R-I": 0.407}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.651, "V-R": 0.377, "R-I": 0.407}, "sun": true
     },
     "(65225) 2002 EK44|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.693, "V-R": 0.401, "R-I": 0.334}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.693, "V-R": 0.401, "R-I": 0.334}, "sun": true
     },
     "(65407) 2002 RP120|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.846, "V-R": 0.489, "R-I": 0.484}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.846, "V-R": 0.489, "R-I": 0.484}, "sun": true
     },
     "(65489) Ceto|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.879, "V-R": 0.547, "R-I": 0.411}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.879, "V-R": 0.547, "R-I": 0.411}, "sun": true
     },
     "(66452) 1999 OF4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.032, "V-R": 0.673, "R-I": 0.601}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.032, "V-R": 0.673, "R-I": 0.601}, "sun": true
     },
     "(66652) Borasisi|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.646, "R-I": 0.647}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.646, "R-I": 0.647}, "sun": true
     },
     "(69986) 1998 WW24|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.756, "V-R": 0.463, "R-I": 0.659}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.756, "V-R": 0.463, "R-I": 0.659}, "sun": true
     },
     "(69988) 1998 WA31|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.786, "V-R": 0.492, "R-I": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.786, "V-R": 0.492, "R-I": 0.530}, "sun": true
     },
     "(69990) 1998 WU31|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.505, "R-I": 0.722}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.505, "R-I": 0.722}, "sun": true
     },
     "(73480) 2002 PN34|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.818, "V-R": 0.514}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.818, "V-R": 0.514}, "sun": true
     },
     "(76804) 2000 QE|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.803, "V-R": 0.446, "R-I": 0.443}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.803, "V-R": 0.446, "R-I": 0.443}, "sun": true
     },
     "(79360) Sila-Nunam|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.055, "V-R": 0.666, "R-I": 0.609}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.055, "V-R": 0.666, "R-I": 0.609}, "sun": true
     },
     "(79978) 1999 CC158|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.996, "V-R": 0.611, "R-I": 0.619}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.996, "V-R": 0.611, "R-I": 0.619}, "sun": true
     },
     "(79983) 1999 DF9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.710, "R-I": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.710, "R-I": 0.650}, "sun": true
     },
     "(82075) 2000 YW134|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.922, "V-R": 0.503, "R-I": 0.581}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.922, "V-R": 0.503, "R-I": 0.581}, "sun": true
     },
     "(82155) 2001 FZ173|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.864, "V-R": 0.546, "R-I": 0.508}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.864, "V-R": 0.546, "R-I": 0.508}, "sun": true
     },
     "(82158) 2001 FP185|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.572, "R-I": 0.458}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.572, "R-I": 0.458}, "sun": true
     },
     "(83982) Crantor|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.105, "V-R": 0.761, "R-I": 0.667}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.105, "V-R": 0.761, "R-I": 0.667}, "sun": true
     },
     "(84522) 2002 TC302|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 1.067, "V-R": 0.655, "R-I": 0.660}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.067, "V-R": 0.655, "R-I": 0.660}, "sun": true
     },
     "(84709) 2002 VW120|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.855, "V-R": 0.462, "R-I": 0.548}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.855, "V-R": 0.462, "R-I": 0.548}, "sun": true
     },
     "(84719) 2002 VR128|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.935, "V-R": 0.605}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.935, "V-R": 0.605}, "sun": true
     },
     "(84922) 2003 VS2|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.930, "V-R": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.930, "V-R": 0.590}, "sun": true
     },
     "(85633) 1998 KR65|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.095, "V-R": 0.628, "R-I": 0.790}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.095, "V-R": 0.628, "R-I": 0.790}, "sun": true
     },
     "(86047) 1999 OY3|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.726, "V-R": 0.345, "R-I": 0.277}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.726, "V-R": 0.345, "R-I": 0.277}, "sun": true
     },
     "(86177) 1999 RY215|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.719, "V-R": 0.358, "R-I": 0.631}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.719, "V-R": 0.358, "R-I": 0.631}, "sun": true
     },
     "(87269) 2000 OO67|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.080, "V-R": 0.654, "R-I": 0.593}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.080, "V-R": 0.654, "R-I": 0.593}, "sun": true
     },
     "(87555) 2000 QB243|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.763, "V-R": 0.383, "R-I": 0.729}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.763, "V-R": 0.383, "R-I": 0.729}, "sun": true
     },
     "(88269) 2001 KF77|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.080, "V-R": 0.730}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.080, "V-R": 0.730}, "sun": true
     },
-    "(90377) Sedna|MBOSS": {"tags": ["featured", "solar_system", "dwarf_planet", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 1.179, "V-R": 0.739, "R-I": 0.654}, "sun": true, "albedo": 0.399
+    "(90377) Sedna|MBOSS": {"tags": ["featured", "solar_system", "planet-geophys", "dwarf_planet", "minor_body", "tno", "detached"],
+        "filters": "Landolt", "indices": {"B-V": 1.179, "V-R": 0.739, "R-I": 0.654}, "sun": true, "albedo": 0.399
     }, // albedo from fyr02's sheet
-    "(90482) Orcus|MBOSS": {"tags": ["featured", "solar_system", "dwarf_planet", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.670, "V-R": 0.376, "R-I": 0.372}, "sun": true, "albedo": 0.231
+    "(90482) Orcus|MBOSS": {"tags": ["featured", "solar_system", "planet-geophys", "dwarf_planet", "minor_body", "tno", "plutino"],
+        "filters": "Landolt", "indices": {"B-V": 0.670, "V-R": 0.376, "R-I": 0.372}, "sun": true, "albedo": 0.231
     }, // albedo from fyr02's sheet
     "(90568) 2004 GV9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.895, "V-R": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.895, "V-R": 0.520}, "sun": true
     },
     "(91133) 1998 HK151|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.645, "V-R": 0.520, "R-I": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.645, "V-R": 0.520, "R-I": 0.390}, "sun": true
     },
     "(91205) 1998 US43|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.691, "V-R": 0.446, "R-I": 0.347}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.691, "V-R": 0.446, "R-I": 0.347}, "sun": true
     },
     "(91554) 1999 RZ215|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.771, "V-R": 0.575, "R-I": 0.539}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.771, "V-R": 0.575, "R-I": 0.539}, "sun": true
     },
     "(95626) 2002 GZ32|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.674, "V-R": 0.576, "R-I": 0.538}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.674, "V-R": 0.576, "R-I": 0.538}, "sun": true
     },
     "(99328) 2001 UY123|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.890, "V-R": 0.537, "R-I": 0.434}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.890, "V-R": 0.537, "R-I": 0.434}, "sun": true
     },
     "(105685) 2000 SC51|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 1.016, "V-R": 0.444, "R-I": 0.452}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.016, "V-R": 0.444, "R-I": 0.452}, "sun": true
     },
     "(111113) 2001 VK85|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.822, "V-R": 0.462, "R-I": 0.558}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.822, "V-R": 0.462, "R-I": 0.558}, "sun": true
     },
     "(118228) 1996 TQ66|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.186, "V-R": 0.670, "R-I": 0.746}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.186, "V-R": 0.670, "R-I": 0.746}, "sun": true
     },
     "(118379) 1999 HC12|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.894, "V-R": 0.490, "R-I": 0.343}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.894, "V-R": 0.490, "R-I": 0.343}, "sun": true
     },
     "(118702) 2000 OM67|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.590}, "sun": true
     },
     "(119068) 2001 KC77|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.910, "V-R": 0.560}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.910, "V-R": 0.560}, "sun": true
     },
     "(119315) 2001 SQ73|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.670, "V-R": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.670, "V-R": 0.460}, "sun": true
     },
     "(119951) 2002 KX14|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.050, "V-R": 0.607}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.050, "V-R": 0.607}, "sun": true
     },
     "(119979) 2002 WC19|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 1.040, "V-R": 0.630}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.040, "V-R": 0.630}, "sun": true
     },
     "(120061) 2003 CO1|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.743, "V-R": 0.472, "R-I": 0.494}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.743, "V-R": 0.472, "R-I": 0.494}, "sun": true
     },
     "(120132) 2003 FY128|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 1.021, "V-R": 0.614, "R-I": 0.540}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.021, "V-R": 0.614, "R-I": 0.540}, "sun": true
     },
     "(120178) 2003 OP32|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.662, "V-R": 0.375, "R-I": 0.305}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.662, "V-R": 0.375, "R-I": 0.305}, "sun": true
     },
     "(120181) 2003 UR292|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.025, "V-R": 0.635}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.025, "V-R": 0.635}, "sun": true
     },
     "(120216) 2004 EW95|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.693, "V-R": 0.375, "R-I": 0.215}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.693, "V-R": 0.375, "R-I": 0.215}, "sun": true
     },
     "(120347) Salacia|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.664, "V-R": 0.403, "R-I": 0.433}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.664, "V-R": 0.403, "R-I": 0.433}, "sun": true
     },
     "(120348) 2004 TY364|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.059, "V-R": 0.601, "R-I": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.059, "V-R": 0.601, "R-I": 0.520}, "sun": true
     },
     "(120453) 1988 RE12|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.826, "V-R": 0.388, "R-I": 0.483}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.826, "V-R": 0.388, "R-I": 0.483}, "sun": true
     },
     "(121725) Aphidas|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.060, "V-R": 0.648, "R-I": 0.679}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.060, "V-R": 0.648, "R-I": 0.679}, "sun": true
     },
     "(124729) 2001 SB173|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.992, "V-R": 0.503, "R-I": 0.424}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.992, "V-R": 0.503, "R-I": 0.424}, "sun": true
     },
     "(127546) 2002 XU93|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.731, "V-R": 0.410, "R-I": 0.443}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.731, "V-R": 0.410, "R-I": 0.443}, "sun": true
     },
     "(129772) 1999 HR11|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.530, "R-I": 0.800}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.530, "R-I": 0.800}, "sun": true
     },
-    "(134340) Pluto|MBOSS": {"tags": ["solar_system", "minor_body", "dwarf_planet", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.867, "V-R": 0.515, "R-I": 0.400}, "albedo": 0.52, "sun": true
+    "(134340) Pluto|MBOSS": {"tags": ["solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "plutino"],
+        "filters": "Landolt", "indices": {"B-V": 0.867, "V-R": 0.515, "R-I": 0.400}, "albedo": 0.52, "sun": true
     },
     "(134860) 2000 OJ67|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.050, "V-R": 0.670, "R-I": 0.600}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.050, "V-R": 0.670, "R-I": 0.600}, "sun": true
     },
     "(135182) 2001 QT322|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.710, "V-R": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.710, "V-R": 0.530}, "sun": true
     },
-    "(136108) Haumea|MBOSS": {"tags": ["featured", "solar_system", "dwarf_planet", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.633, "V-R": 0.353, "R-I": 0.330}, "sun": true, "albedo": 0.66
+    "(136108) Haumea|MBOSS": {"tags": ["featured", "solar_system", "planet-geophys", "dwarf_planet", "minor_body", "tno", "classical", "classical-h"],
+        "filters": "Landolt", "indices": {"B-V": 0.633, "V-R": 0.353, "R-I": 0.330}, "sun": true, "albedo": 0.66
     }, // albedo from https://arxiv.org/abs/1904.00522
-    "(136199) Eris|MBOSS": {"tags": ["solar_system", "minor_body", "dwarf_planet", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.781, "V-R": 0.393, "R-I": 0.363}, "sun": true, "albedo": 0.957
+    "(136199) Eris|MBOSS": {"tags": ["solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "detached"],
+        "filters": "Landolt", "indices": {"B-V": 0.781, "V-R": 0.393, "R-I": 0.363}, "sun": true, "albedo": 0.957
     }, // albedo from fyr02's sheet
     "(136204) 2003 WL7|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.480}, "sun": true
     },
-    "(136472) Makemake|MBOSS": {"tags": ["solar_system", "minor_body", "dwarf_planet", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.840, "V-R": 0.480}, "sun": true, "albedo": 0.83
+    "(136472) Makemake|MBOSS": {"tags": ["solar_system", "planet-geophys", "minor_body", "dwarf_planet", "tno", "classical", "classical-h"],
+        "filters": "Landolt", "indices": {"B-V": 0.840, "V-R": 0.480}, "sun": true, "albedo": 0.83
     }, // albedo from fyr02's sheet
     "(137294) 1999 RE215|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.003, "V-R": 0.710, "R-I": 0.571}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.003, "V-R": 0.710, "R-I": 0.571}, "sun": true
     },
     "(137295) 1999 RB216|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.897, "V-R": 0.522, "R-I": 0.506}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.897, "V-R": 0.522, "R-I": 0.506}, "sun": true
     },
     "(138537) 2000 OK67|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.821, "V-R": 0.583, "R-I": 0.524}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.821, "V-R": 0.583, "R-I": 0.524}, "sun": true
     },
     "(143707) 2003 UY117|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.950, "V-R": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.950, "V-R": 0.590}, "sun": true
     },
     "(144897) 2004 UX10|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.950, "V-R": 0.575}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.950, "V-R": 0.575}, "sun": true
     },
     "(145451) 2005 RM43|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.590, "V-R": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.590, "V-R": 0.390}, "sun": true
     },
     "(145452) 2005 RN43|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.940, "V-R": 0.592, "R-I": 0.486}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.940, "V-R": 0.592, "R-I": 0.486}, "sun": true
     },
     "(145453) 2005 RR43|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.389}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.389}, "sun": true
     },
     "(145480) 2005 TB190|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.980, "V-R": 0.562, "R-I": 0.578}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.980, "V-R": 0.562, "R-I": 0.578}, "sun": true
     },
     "(145486) 2005 UJ438|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.946, "V-R": 0.641, "R-I": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.946, "V-R": 0.641, "R-I": 0.510}, "sun": true
     },
     "(148209) 2000 CR105|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.771, "V-R": 0.509, "R-I": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.771, "V-R": 0.509, "R-I": 0.590}, "sun": true
     },
     "(148975) 2001 XA255|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.680, "R-I": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.680, "R-I": 0.440}, "sun": true
     },
     "(160427) 2005 RL43|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.120, "V-R": 0.730}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.120, "V-R": 0.730}, "sun": true
     },
     "(163135) 2002 CT22|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.690, "V-R": 0.382, "R-I": 0.360}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.690, "V-R": 0.382, "R-I": 0.360}, "sun": true
     },
     "(168703) 2000 GP183|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.669, "V-R": 0.445, "R-I": 0.463}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.669, "V-R": 0.445, "R-I": 0.463}, "sun": true
     },
     "(174567) Varda|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.892, "V-R": 0.556, "R-I": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.892, "V-R": 0.556, "R-I": 0.510}, "sun": true
     },
     "(181708) 1993 FW|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.023, "V-R": 0.583, "R-I": 0.439}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.023, "V-R": 0.583, "R-I": 0.439}, "sun": true
     },
     "(181855) 1998 WT31|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.774, "V-R": 0.453, "R-I": 0.326}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.774, "V-R": 0.453, "R-I": 0.326}, "sun": true
     },
     "(181874) 1999 HW11|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.840, "V-R": 0.499, "R-I": 0.493}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.840, "V-R": 0.499, "R-I": 0.493}, "sun": true
     },
     "(182397) 2001 QW297|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.020, "V-R": 0.580, "R-I": 0.670}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.020, "V-R": 0.580, "R-I": 0.670}, "sun": true
     },
     "(182934) 2002 GJ32|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.330, "V-R": 0.590, "R-I": 0.420}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.330, "V-R": 0.590, "R-I": 0.420}, "sun": true
     },
     "(192388) 1996 RD29|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.741, "V-R": 0.421, "R-I": 0.388}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.741, "V-R": 0.421, "R-I": 0.388}, "sun": true
     },
     "(192929) 2000 AT44|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.707, "V-R": 0.354, "R-I": 0.318}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.707, "V-R": 0.354, "R-I": 0.318}, "sun": true
     },
     "(208996) 2003 AZ84|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.738, "V-R": 0.430, "R-I": 0.473}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.738, "V-R": 0.430, "R-I": 0.473}, "sun": true
     },
     "(248835) 2006 SX368|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.758, "V-R": 0.478, "R-I": 0.471}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.758, "V-R": 0.478, "R-I": 0.471}, "sun": true
     },
     "(250112) 2002 KY14|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.060, "V-R": 0.709, "R-I": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.060, "V-R": 0.709, "R-I": 0.650}, "sun": true
     },
     "(275809) 2001 QY297|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.947, "V-R": 0.479, "R-I": 0.651}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.947, "V-R": 0.479, "R-I": 0.651}, "sun": true
     },
     "(278361) 2007 JJ43|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.020, "V-R": 0.590, "R-I": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.020, "V-R": 0.590, "R-I": 0.500}, "sun": true
     },
     "(281371) 2008 FC76|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.987, "V-R": 0.685, "R-I": 0.652}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.987, "V-R": 0.685, "R-I": 0.652}, "sun": true
     },
     "(303775) 2005 QU182|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.877, "V-R": 0.593}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.877, "V-R": 0.593}, "sun": true
     },
     "(307261) 2002 MS4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.690, "V-R": 0.380}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.690, "V-R": 0.380}, "sun": true
     },
     "(307982) 2004 PG115|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.966, "V-R": 0.664, "R-I": 0.633}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.966, "V-R": 0.664, "R-I": 0.633}, "sun": true
     },
     "(308933) 2006 SQ372|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.030, "V-R": 0.590, "R-I": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.030, "V-R": 0.590, "R-I": 0.650}, "sun": true
     },
     "(309139) 2006 XQ51|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.410}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.410}, "sun": true
     },
     "(309737) 2008 SJ236|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.010, "V-R": 0.588, "R-I": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.010, "V-R": 0.588, "R-I": 0.500}, "sun": true
     },
     "(309741) 2008 UZ6|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.590}, "sun": true
     },
     "(315898) 2008 QD4|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.460}, "sun": true
     },
     "(316431) 2010 TH167|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "trojan", "trojan-j"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.460}, "sun": true
     },
     "(330759) 2008 SO218|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.890, "V-R": 0.550, "R-I": 0.500}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.890, "V-R": 0.550, "R-I": 0.500}, "sun": true
     },
     "(336756) 2010 NV1|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.765, "V-R": 0.512, "R-I": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.765, "V-R": 0.512, "R-I": 0.390}, "sun": true
     },
     "(341275) 2007 RG283|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.790, "V-R": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.790, "V-R": 0.470}, "sun": true
     },
     "(341520) Mors-Somn|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 1.290, "V-R": 0.740, "R-I": 0.630}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.290, "V-R": 0.740, "R-I": 0.630}, "sun": true
     },
     "(342842) 2008 YB3|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.774, "V-R": 0.472, "R-I": 0.490}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.774, "V-R": 0.472, "R-I": 0.490}, "sun": true
     },
     "(346889) Rhiphonos|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.550}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.550}, "sun": true
     },
     "(349933) 2009 YF7|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.460}, "sun": true
     },
     "(382004) 2010 RM64|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.000, "V-R": 0.550}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.000, "V-R": 0.550}, "sun": true
     },
     "(385185) 1993 RO|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.590, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.590, "R-I": 0.480}, "sun": true
     },
     "(385191) 1997 RT5|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.075, "V-R": 0.474, "R-I": 0.539}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.075, "V-R": 0.474, "R-I": 0.539}, "sun": true
     },
     "(385194) 1998 KG62|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.039, "V-R": 0.609, "R-I": 0.610}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.039, "V-R": 0.609, "R-I": 0.610}, "sun": true
     },
     "(385199) 1999 OE4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.103, "V-R": 0.567, "R-I": 0.414}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.103, "V-R": 0.567, "R-I": 0.414}, "sun": true
     },
     "(385437) 2003 GH55|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.120, "V-R": 0.665, "R-I": 0.859}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.120, "V-R": 0.665, "R-I": 0.859}, "sun": true
     },
     "(385571) Otrera|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.420, "R-I": 0.460}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.420, "R-I": 0.460}, "sun": true
     },
     "(385607) 2005 EO297|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.840, "V-R": 0.480, "R-I": 0.570}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.840, "V-R": 0.480, "R-I": 0.570}, "sun": true
     },
     "(385695) 2005 TO74|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.850, "V-R": 0.490, "R-I": 0.420}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.850, "V-R": 0.490, "R-I": 0.420}, "sun": true
     },
     "(416400) 2003 UZ117|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.663, "V-R": 0.354, "R-I": 0.335}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.663, "V-R": 0.354, "R-I": 0.335}, "sun": true
     },
     "(418993) 2009 MS9|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.840, "V-R": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.840, "V-R": 0.520}, "sun": true
     },
     "(427507) 2002 DH5|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.663, "V-R": 0.391, "R-I": 0.416}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.663, "V-R": 0.391, "R-I": 0.416}, "sun": true
     },
     "(444030) 2004 NT33|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.641, "V-R": 0.403, "R-I": 0.403}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.641, "V-R": 0.403, "R-I": 0.403}, "sun": true
     },
     "(445473) 2010 VZ98|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 1.100, "V-R": 0.670}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.100, "V-R": 0.670}, "sun": true
     },
     "(447178) 2005 RO43|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.770, "V-R": 0.470}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.770, "V-R": 0.470}, "sun": true
     },
     "(449097) 2012 UT68|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.020, "V-R": 0.660}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.020, "V-R": 0.660}, "sun": true
     },
     "(455171) 1999 OM4|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.137, "V-R": 0.602, "R-I": 0.499}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.137, "V-R": 0.602, "R-I": 0.499}, "sun": true
     },
     "(459865) 2013 XZ8|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.450}, "sun": true
     },
     "(459971) 2014 ON6|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.970, "V-R": 0.580}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.970, "V-R": 0.580}, "sun": true
     },
     "(463368) 2012 VU85|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.070, "V-R": 0.630}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.070, "V-R": 0.630}, "sun": true
     },
     "(463663) 2014 HY123|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.670, "V-R": 0.490}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.670, "V-R": 0.490}, "sun": true
     },
     "(469306) 1999 CD158|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.864, "V-R": 0.520, "R-I": 0.575}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.864, "V-R": 0.520, "R-I": 0.575}, "sun": true
     },
     "(469333) 2000 PE30|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.752, "V-R": 0.373, "R-I": 0.410}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.752, "V-R": 0.373, "R-I": 0.410}, "sun": true
     },
     "(469362) 2001 KB77|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.890, "V-R": 0.457, "R-I": 0.548}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.890, "V-R": 0.457, "R-I": 0.548}, "sun": true
     },
     "(469372) 2001 QF298|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "plutino"],
-        "filters": "UBVRI", "indices": {"B-V": 0.695, "V-R": 0.388, "R-I": 0.360}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.695, "V-R": 0.388, "R-I": 0.360}, "sun": true
     },
     "(469750) 2005 PU21|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 1.140, "V-R": 0.650, "R-I": 0.680}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.140, "V-R": 0.650, "R-I": 0.680}, "sun": true
     },
     "(470316) 2007 OC10|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.876, "V-R": 0.553, "R-I": 0.471}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.876, "V-R": 0.553, "R-I": 0.471}, "sun": true
     },
     "(470599) 2008 OG19|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.940, "V-R": 0.530, "R-I": 0.590}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.940, "V-R": 0.530, "R-I": 0.590}, "sun": true
     },
     "(471339) 2011 ON45|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.110, "V-R": 0.705}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.110, "V-R": 0.705}, "sun": true
     },
     "(474640) 2004 VN112|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.900, "V-R": 0.520, "R-I": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.900, "V-R": 0.520, "R-I": 0.450}, "sun": true
     },
     "(506479) 2003 HB57|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.830, "V-R": 0.480, "R-I": 0.540}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.830, "V-R": 0.480, "R-I": 0.540}, "sun": true
     },
     "(508770) 1995 WY2|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.030, "V-R": 0.600, "R-I": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.030, "V-R": 0.600, "R-I": 0.510}, "sun": true
     },
     "(523588) 2000 CN105|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.100, "V-R": 0.636, "R-I": 0.640}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.100, "V-R": 0.636, "R-I": 0.640}, "sun": true
     },
     "(523591) 2001 QD298|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.970, "V-R": 0.670}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.970, "V-R": 0.670}, "sun": true
     },
     "(523597) 2002 QX47|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.700, "V-R": 0.380}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.700, "V-R": 0.380}, "sun": true
     },
     "(523620) 2007 RH283|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.430}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.430}, "sun": true
     },
     "(523622) 2007 TG422|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.880, "V-R": 0.510, "R-I": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.880, "V-R": 0.510, "R-I": 0.510}, "sun": true
     },
     "(523676) 2013 UL10|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.970, "V-R": 0.670}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.970, "V-R": 0.670}, "sun": true
     },
     "(523785) 2015 CM3|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 1.210, "V-R": 0.570}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.210, "V-R": 0.570}, "sun": true
     },
     "(523899) 1997 CV29|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 1.210, "V-R": 0.650}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.210, "V-R": 0.650}, "sun": true
     },
     "(523965) 1998 XY95|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.930, "V-R": 0.720, "R-I": 0.752}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.930, "V-R": 0.720, "R-I": 0.752}, "sun": true
     },
     "(523983) 1999 RY214|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.693, "V-R": 0.565, "R-I": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.693, "V-R": 0.565, "R-I": 0.530}, "sun": true
     },
     "(524049) 2000 CQ105|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.671, "V-R": 0.449, "R-I": 0.346}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.671, "V-R": 0.449, "R-I": 0.346}, "sun": true
     },
     "(524217) 2001 RZ143|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 1.080, "V-R": 0.510, "R-I": 0.490}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 1.080, "V-R": 0.510, "R-I": 0.490}, "sun": true
     },
     "(524834) 2003 YL179|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "classical", "classical-c"],
-        "filters": "UBVRI", "indices": {"B-V": 0.810, "V-R": 0.450}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.810, "V-R": 0.450}, "sun": true
     },
     "(525815) 2005 SD278|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "resonant"],
-        "filters": "UBVRI", "indices": {"B-V": 0.970, "V-R": 0.560, "R-I": 0.530}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.970, "V-R": 0.560, "R-I": 0.530}, "sun": true
     },
     "(527328) 2007 TK422|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.710, "V-R": 0.510}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.710, "V-R": 0.510}, "sun": true
     },
     "(527443) 2007 UM126|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.740, "V-R": 0.435, "R-I": 0.440}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.740, "V-R": 0.435, "R-I": 0.440}, "sun": true
     },
     "(527603) 2007 VJ305|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "detached"],
-        "filters": "UBVRI", "indices": {"B-V": 0.920, "V-R": 0.520, "R-I": 0.520}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.920, "V-R": 0.520, "R-I": 0.520}, "sun": true
     },
     "527604|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.830, "V-R": 0.470, "R-I": 0.480}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.830, "V-R": 0.470, "R-I": 0.480}, "sun": true
     },
     "(528219) 2008 KV42|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.420}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.820, "V-R": 0.470, "R-I": 0.420}, "sun": true
     },
     "530664|MBOSS": {"tags": ["solar_system", "minor_body", "tno", "scattered"],
-        "filters": "UBVRI", "indices": {"B-V": 0.690, "V-R": 0.390}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.690, "V-R": 0.390}, "sun": true
     },
     "530930|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid", "centaur"],
-        "filters": "UBVRI", "indices": {"B-V": 0.720, "V-R": 0.400}, "sun": true
+        "filters": "Landolt", "indices": {"B-V": 0.720, "V-R": 0.400}, "sun": true
     },
     /*"1998 KY26|MBOSS": {"tags": ["solar_system", "minor_body", "asteroid"],
-    #	"filters": "UBVRI", "indices": {"B-R": 0.083, "V-R": 0.058, "R-I": 0.088}, "sun": false
+    #	"filters": "Landolt", "indices": {"B-R": 0.083, "V-R": 0.058, "R-I": 0.088}, "sun": false
     #},*/
 }

--- a/spectra/11_exoplanets.json5
+++ b/spectra/11_exoplanets.json5
@@ -20,186 +20,186 @@
         "https://arxiv.org/abs/1109.3116"
     ],
     "Zelario": [
-        "The ExoColors table by Zelario",
+        "The ExoColors table by Zelario (Fireon)",
         "https://docs.google.com/spreadsheets/d/1kg9lktTwNhHVVyAS2FhccvLMnddI4L0Ot67f-kYFIFM"
     ],
-    "Class I|Sudarsky2000": {"tags": ["featured", "exoplanet", "extrasolar", "planet", "class"],
+    "Class I|Sudarsky2000": {"tags": ["featured", "extrasolar", "planet", "class"],
         "nm": [300, 350, 400, 450, 500, 550, 600, 650, 700, 800, 900, 1000],
         "br": [0.88, 0.85, 0.78, 0.69, 0.67, 0.69, 0.67, 0.64, 0.58, 0.6, 0.45, 0.5],
         "albedo": true
     },
-    "Class II|Sudarsky2000": {"tags": ["featured", "exoplanet", "extrasolar", "planet", "class"],
+    "Class II|Sudarsky2000": {"tags": ["featured", "extrasolar", "planet", "class"],
         "nm": [300, 350, 400, 450, 500, 550, 600, 650, 700, 800, 900, 1000],
         "br": [0.99, 0.99, 0.99, 0.99, 0.98, 0.97, 0.94, 0.95, 0.9, 0.85, 0.75, 0.75],
         "albedo": true
     },
-    "Class III|Sudarsky2000": {"tags": ["featured", "exoplanet", "extrasolar", "planet", "class"],
+    "Class III|Sudarsky2000": {"tags": ["featured", "extrasolar", "planet", "class"],
         "nm": [300, 350, 400, 450, 500, 550, 600, 650, 700, 800, 900, 1000],
         "br": [0.67, 0.52, 0.42, 0.3, 0.2, 0.13, 0.07, 0.06, 0.04, 0.02, 0, 0],
         "albedo": true
     },
-    "Class IV|Sudarsky2000": {"tags": ["featured", "exoplanet", "extrasolar", "planet", "class"],
+    "Class IV|Sudarsky2000": {"tags": ["featured", "extrasolar", "planet", "class"],
         "nm": [300, 350, 400, 450, 500, 550, 600, 650, 700, 800, 900, 1000],
         "br": [0.2, 0.15, 0.1, 0.06, 0.03, 0.01, 0, 0.01, 0, 0, 0, 0],
         "albedo": true
     },
-    "Class V|Sudarsky2000": {"tags": ["featured", "exoplanet", "extrasolar", "planet", "class"],
+    "Class V|Sudarsky2000": {"tags": ["featured", "extrasolar", "planet", "class"],
         "nm": [300, 350, 400, 450, 500, 550, 585, 620, 650, 700, 800, 900, 1000],
         "br": [0.4, 0.57, 0.65, 0.66, 0.66, 0.55, 0, 0.5, 0.62, 0.65, 0.5, 0.65, 0.64],
         "albedo": true
     },
-    "HD 189733 b|Berdyugina2010, Berdyugina2011": {"tags": ["featured", "exoplanet", "extrasolar", "planet"],
-        "filters": "UBVRI", "bands": ["U", "B", "V", "I"], "br": [0.62, 0.61, 0.28, 0], "albedo": true
+    "HD 189733 b|Berdyugina2010, Berdyugina2011": {"tags": ["featured", "extrasolar", "planet", "planet-geophys"],
+        "filters": "Landolt", "bands": ["U", "B", "V", "I"], "br": [0.62, 0.61, 0.28, 0], "albedo": true
     },
-    "HD 189733 b|Evans2013, Schwartz2015": {"tags": ["exoplanet", "extrasolar", "planet"],
+    "HD 189733 b|Evans2013, Schwartz2015": {"tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [290, 368, 370, 416, 459, 510, 547, 875], "br": [0.45, 0.39, 0.374, 0.32, 0.17, 0.043, 0.02, 0.025], "albedo": true
     },
-    "υ Andromedae b|Berdyugina2011": {"tags": ["exoplanet", "extrasolar", "planet"],
-        "filters": "UBVRI", "bands": ["U", "B", "V"], "br": [0.53, 0.67, 0.29], "albedo": true
+    "Ups And b|Berdyugina2011": {"tags": ["featured", "extrasolar", "planet", "planet-geophys"],
+        "filters": "Landolt", "bands": ["U", "B", "V"], "br": [0.53, 0.67, 0.29], "albedo": true
     },
-    "WASP-18 b": {"tags": ["exoplanet", "extrasolar", "planet"],
+    "WASP-18 b": {"tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [440, 788, 900], "br": [0.075, 0.048, 0.05], "albedo": true
     },
-    "WASP-12 b": {"tags": ["exoplanet", "extrasolar", "planet"],
+    "WASP-12 b": {"tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [271, 430, 900], "br": [0.039, 0.032, 0.17], "albedo": true
     },
-    "WASP-43 b": {"tags": ["exoplanet", "extrasolar", "planet"],
+    "WASP-43 b": {"tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [398, 538, 788, 1400, 4050], "br": [0.28, 0.05, 0.12, 0.24, 0.09], "albedo": true
     },
-    "τ Bootis b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+    "TAU Boo b|Zelario": {
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [415, 430, 460, 780],
         "br": [0.117, 0.234, 0.029, 0.022],
         "albedo": true
     },
-    "υ Andromedae b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+    "UPS And b|Zelario": {
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [367, 440, 460, 542],
         "br": [0.467, 0.584, 0.329, 0.251],
         "albedo": true
     },
     "51 Pegasi b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [490, 560],
         "br": [0.113, 0.043],
         "albedo": true
     },
     "55 Cancri e|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [521, 581, 746],
         "br": [0.211, 0.588, 0.244],
         "albedo": true
     },
     "CoRoT-1 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [439, 546, 600, 710, 907],
         "br": [0.340, 0.376, 0.167, 0.064, 0.330],
         "albedo": true
     },
     "CoRoT-2 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [439, 546, 600, 710],
         "br": [0.040, 0.023, 0.076, 0.139],
         "albedo": true
     },
     "CoRoT-3 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [600, 710],
         "br": [0.672, 0.050],
         "albedo": true
     },
     "HAT-P-7 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [558, 598, 746],
         "br": [0.157, 0.137, 0.163],
         "albedo": true
     },
     "HD 189733 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [325, 368, 416, 446, 459, 502, 547, 1000],
         "br": [0.477, 0.467, 0.290, 0.116, 0.147, 0.093, 0.055, 0.055],
         "albedo": true
     },
     "HD 209458 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [521, 581],
         "br": [0.036, 0.105],
         "albedo": true
     },
     "Kepler-13 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [598, 746],
         "br": [0.466, 0.727],
         "albedo": true
     },
     "TrES-2 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [558, 598],
         "br": [0.932, 0.031],
         "albedo": true
     },
     "TrES-3 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [350, 558, 746, 766, 980],
         "br": [0.210, 0.109, 0.130, 0.115, 0.213],
         "albedo": true
     },
     "KELT-1 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [746, 910],
         "br": [0.468, 0.385],
         "albedo": true
     },
     "KELT-9 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [363, 746, 910],
         "br": [0.040, 0.150, 0.361],
         "albedo": true
     },
     "WASP-3 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [558, 746],
         "br": [0.439, 0.153],
         "albedo": true
     },
     "WASP-12 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [360, 460, 547, 746, 847, 910, 1022, 1050],
         "br": [0.062, 0.027, 0.015, 0.159, 0.055, 0.615, 0.270, 0.085],
         "albedo": true
     },
     "WASP-18 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [474, 746, 904, 1400],
         "br": [0.032, 0.196, 0.354, 0.005],
         "albedo": true
     },
     "WASP-19 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [476, 685, 746, 806, 916],
         "br": [0.083, 0.150, 0.157, 0.108, 0.035],
         "albedo": true
     },
     "WASP-33 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [356, 515, 546, 746, 908, 910, 1037],
         "br": [0.010, 0.100, 0.133, 0.079, 0.912, 0.134, 0.584],
         "albedo": true
     },
     "WASP-43 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [398, 556, 580, 680, 746, 760, 785, 893, 916, 1400],
         "br": [0.277, 0.009, 0.002, 0.108, 0.108, 0.335, 0.317, 0.133, 0.167, 0.32],
         "albedo": true
     },
     "WASP-46 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [450, 610, 746, 760, 893],
         "br": [0.740, 0.533, 0.119, 0.464, 0.028],
         "albedo": true
     },
     "WASP-121 b|Zelario": {
-        "tags": ["exoplanet", "extrasolar", "planet"],
+        "tags": ["extrasolar", "planet", "planet-geophys"],
         "nm": [746, 830, 916, 937, 1035],
         "br": [0.186, 0.004, 0.078, 0.078, 0.013],
         "albedo": true


### PR DESCRIPTION
- Added a new tag 'planet-geophys', geophysical planets, to help sort for large, gravitationally spherical worlds.
- Added Venus and Titan's surface spectra.