### PR TITLE
Updated Quaoar's albedo and added Gonggong

### DIFF
--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -103,6 +103,10 @@
         "Eight-color maps of Titan’s surface from spectroscopy with Huygens’ DISR",
         "DOI: 10.1016/j.icarus.2015.06.010", "https://www.sciencedirect.com/science/article/pii/S0019103515002547"
     ],
+    "Boehnhardt2014": [
+        "Photometry of Transneptunian Objects for the Herschel Key Program ‘TNOs are Cool’",
+        "DOI: 10.1007/s11038-014-9450-x", "https://link.springer.com/article/10.1007/s11038-014-9450-x"
+    ],
 
     "Mercury|Mallama2017": {"tags": ["featured", "solar system", "planet geophysical", "planet"],
         "nm": [360, 436, 549, 641, 700, 798, 900], "br": [0.087, 0.105, 0.142, 0.158, 0.172, 0.180, 0.208], "albedo": true

--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -433,6 +433,9 @@
         1.201, 1.201, 1.087, 1.159, 1.018, 1.079, 0.881, 1.072, 1.13],
         "albedo": 0.83, // albedo from zelario's sheet
     },
+    "(225088) Gonggong|Boehnhardt2014": {"tags": ["featured", "solar system", "planet geophysical", "minor body", "dwarf planet", "tno", "detached"],
+        "filters": "Landolt", "indices": {"B-V": 1.38, "V-R": 0.86, "R-I": 0.79}, "sun": true, "albedo": 0.14
+    }, // albedo from Kiss et al. 2019
     //"(486958) Arrokoth|Howett2019": {"tags": ["solar system", "minor body", "tno", "classical", "classical-h"],
     //	"filters": "Hubble", "indices": {"F606W-F814W": 1.03}, "sun": true
     //},

--- a/spectra/08_MBOSS_database.json5
+++ b/spectra/08_MBOSS_database.json5
@@ -713,8 +713,8 @@
         "filters": "UBVRI", "indices": {"B-V": 0.746, "V-R": 0.556, "R-I": 0.368}, "sun": true
     },
     "(50000) Quaoar|MBOSS": {"tags": ["featured", "solar system", "planet geophysical", "minor body", "dwarf planet", "tno", "classical", "classical-h"],
-        "filters": "UBVRI", "indices": {"B-V": 0.958, "V-R": 0.650, "R-I": 0.610}, "sun": true, "albedo": 0.109
-    }, // albedo from fyr02's sheet
+        "filters": "UBVRI", "indices": {"B-V": 0.958, "V-R": 0.650, "R-I": 0.610}, "sun": true, "albedo": 0.124
+    }, // albedo from Pereira et al. 2023
     "(51359) 2000 SC17|MBOSS": {"tags": ["solar system", "minor body", "asteroid", "trojan", "trojan-j"],
         "filters": "UBVRI", "indices": {"B-V": 0.864, "V-R": 0.447, "R-I": 0.438}, "sun": true
     },


### PR DESCRIPTION
- Updated Quaoar's geometric albedo from 0.109 to 0.124. The latter, newer value is obtained from https://ui.adsabs.harvard.edu/abs/2023A%26A...673L...4P/abstract
- Added Gonggong. Color indices are obtained from https://ui.adsabs.harvard.edu/abs/2014EM%26P..114...35B/abstract while albedo is obtained from https://ui.adsabs.harvard.edu/abs/2019Icar..334....3K/abstract
Now all of the eight trans-Neptunian (dwarf) planets are in!