### PR TITLE
Small inner moons of Jupiter

### DIFF
--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -202,9 +202,9 @@
     '(J XVI) Metis: Trailing side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
-        filters: ['Violet', 'Green', '8890A'],
-        br: [0.38, 1, 0.863], // traced from Fig. 6
-        sd: [0.08, 0, 0.173], // traced from Fig. 6
+        filters: ['Violet', 'Green', '8890A', '9680A'],
+        br: [0.38, 1, 0.863, 0.85], // traced from Fig. 6
+        sd: [0.08, 0, 0.173, 0.19], // traced from Fig. 6
         geometric_albedo: ['Galileo_SSI.Clear', 0.054, 0.003], // Table III, log-scaled
         spherical_albedo: ['Galileo_SSI.Clear', 0.027, 0.002], // Table III, log-scaled
     },
@@ -220,9 +220,9 @@
     '(J V) Amalthea: Trailing side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
-        filters: ['Violet', 'Green', '8890A'],
-        br: [0.47, 1, 1.225], // traced from Fig. 6
-        sd: [0.0625, 0, 0.137], // traced from Fig. 6
+        filters: ['Violet', 'Green', '8890A', '9680A'],
+        br: [0.47, 1, 1.225, 1], // traced from Fig. 6
+        sd: [0.0625, 0, 0.137, 0.15], // traced from Fig. 6
         geometric_albedo: ['Galileo_SSI.Clear', 0.080, 0.005], // Table III, log-scaled
         spherical_albedo: ['Galileo_SSI.Clear', 0.029, 0.003], // Table III, log-scaled
     },
@@ -238,9 +238,9 @@
     '(J XIV) Thebe: Trailing side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
-        filters: ['Violet', 'Green', '8890A'],
-        br: [0.6, 1, 1.137], // traced from Fig. 6
-        sd: [0.05, 0, 0.117], // traced from Fig. 6
+        filters: ['Violet', 'Green', '8890A', '9680A'],
+        br: [0.6, 1, 1.137, 1.07], // traced from Fig. 6
+        sd: [0.05, 0, 0.117, 0.15], // traced from Fig. 6
         geometric_albedo: ['Galileo_SSI.Clear', 0.041, 0.003], // Table III, log-scaled
         spherical_albedo: ['Galileo_SSI.Clear', 0.017, 0.002], // Table III, log-scaled
     },

--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -195,45 +195,54 @@
         'The Small Inner Satellites of Jupiter',
         'DOI: 10.1006/icar.1998.5976', 'https://www.sciencedirect.com/science/article/pii/S0019103598959760', 'https://ui.adsabs.harvard.edu/abs/1998Icar..135..360T/abstract'
     ],
-    '(J XVI) Metis: Trailing side|Thomas1998': {
+        'Simonelli2000': [
+        'Leading/Trailing Albedo Asymmetries of Thebe, Amalthea, and Metis',
+        'DOI: 10.1006/icar.2000.6474', 'https://www.sciencedirect.com/science/article/pii/S0019103500964741', 'https://ui.adsabs.harvard.edu/abs/2000Icar..147..353S/abstract'
+    ],
+    '(J XVI) Metis: Trailing side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
         filters: ['Violet', 'Green', '8890A'],
         br: [0.38, 1, 0.863], // traced from Fig. 6
         sd: [0.08, 0, 0.173], // traced from Fig. 6
-        geometric_albedo: ['Galileo_SSI.Clear', 0.054, 0.005], // Table V, log-scaled
+        geometric_albedo: ['Galileo_SSI.Clear', 0.054, 0.003], // Table III, log-scaled
+        spherical_albedo: ['Galileo_SSI.Clear', 0.027, 0.002], // Table III, log-scaled
     },
-    '(J V) Amalthea: Leading side|Thomas1998': {
+    '(J V) Amalthea: Leading side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
         filters: ['Violet', 'Green', '7560A'],
         br: [0.54, 1, 1.14], // traced from Fig. 6
         sd: [0.05, 0, 0.075], // traced from Fig. 6
-        geometric_albedo: ['Galileo_SSI.Clear', 0.103, 0.0092], // Table V, log-scaled
+        geometric_albedo: ['Galileo_SSI.Clear', 0.101, 0.007], // Table III, log-scaled
+        spherical_albedo: ['Galileo_SSI.Clear', 0.036, 0.004], // Table III, log-scaled
     },
-    '(J V) Amalthea: Trailing side|Thomas1998': {
+    '(J V) Amalthea: Trailing side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
         filters: ['Violet', 'Green', '8890A'],
         br: [0.47, 1, 1.225], // traced from Fig. 6
         sd: [0.0625, 0, 0.137], // traced from Fig. 6
-        geometric_albedo: ['Galileo_SSI.Clear', 0.081, 0.0073], // Table V, log-scaled
+        geometric_albedo: ['Galileo_SSI.Clear', 0.080, 0.005], // Table III, log-scaled
+        spherical_albedo: ['Galileo_SSI.Clear', 0.029, 0.003], // Table III, log-scaled
     },
-    '(J XIV) Thebe: Leading side|Thomas1998': {
+    '(J XIV) Thebe: Leading side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
         filters: ['Violet', 'Green', '8890A'],
         br: [0.7125, 1, 1.137], // traced from Fig. 6
         sd: [0.067, 0, 0.117], // traced from Fig. 6
-        geometric_albedo: ['Galileo_SSI.Clear', 0.055, 0.0050], // Table V, log-scaled
+        geometric_albedo: ['Galileo_SSI.Clear', 0.053, 0.004], // Table III, log-scaled
+        spherical_albedo: ['Galileo_SSI.Clear', 0.022, 0.002], // Table III, log-scaled
     },
-    '(J XIV) Thebe: Trailing side|Thomas1998': {
+    '(J XIV) Thebe: Trailing side|Thomas1998, Simonelli2000': {
         tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
         system: 'Galileo_SSI',
         filters: ['Violet', 'Green', '8890A'],
         br: [0.6, 1, 1.137], // traced from Fig. 6
         sd: [0.05, 0, 0.117], // traced from Fig. 6
-        geometric_albedo: ['Galileo_SSI.Clear', 0.044, 0.0040], // Table V, log-scaled
+        geometric_albedo: ['Galileo_SSI.Clear', 0.041, 0.003], // Table III, log-scaled
+        spherical_albedo: ['Galileo_SSI.Clear', 0.017, 0.002], // Table III, log-scaled
     },
     '(J I) Io: Trailing hemisphere|USGSarchive': {
         tags: ['featured', 'Solar system', 'planet geophysical', 'moon', 'Jovian system', 'regular'],

--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -190,6 +190,51 @@
         file: 'spectra/files/Karkoschka1994/jupiter.txtA',
         albedo: true
     },
+    // Jovian small regulars
+        'Thomas1998': [
+        'The Small Inner Satellites of Jupiter',
+        'DOI: 10.1006/icar.1998.5976', 'https://www.sciencedirect.com/science/article/pii/S0019103598959760', 'https://ui.adsabs.harvard.edu/abs/1998Icar..135..360T/abstract'
+    ],
+    '(J XVI) Metis: Trailing side|Thomas1998': {
+        tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
+        system: 'Galileo_SSI',
+        filters: ['Violet', 'Green', '8890A'],
+        br: [0.38, 1, 0.863], // traced from Fig. 6
+        sd: [0.08, 0, 0.173], // traced from Fig. 6
+        geometric_albedo: ['Galileo_SSI.Clear', 0.054, 0.005], // Table V, log-scaled
+    },
+    '(J V) Amalthea: Leading side|Thomas1998': {
+        tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
+        system: 'Galileo_SSI',
+        filters: ['Violet', 'Green', '7560A'],
+        br: [0.54, 1, 1.14], // traced from Fig. 6
+        sd: [0.05, 0, 0.075], // traced from Fig. 6
+        geometric_albedo: ['Galileo_SSI.Clear', 0.103, 0.0092], // Table V, log-scaled
+    },
+    '(J V) Amalthea: Trailing side|Thomas1998': {
+        tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
+        system: 'Galileo_SSI',
+        filters: ['Violet', 'Green', '8890A'],
+        br: [0.47, 1, 1.225], // traced from Fig. 6
+        sd: [0.0625, 0, 0.137], // traced from Fig. 6
+        geometric_albedo: ['Galileo_SSI.Clear', 0.081, 0.0073], // Table V, log-scaled
+    },
+    '(J XIV) Thebe: Leading side|Thomas1998': {
+        tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
+        system: 'Galileo_SSI',
+        filters: ['Violet', 'Green', '8890A'],
+        br: [0.7125, 1, 1.137], // traced from Fig. 6
+        sd: [0.067, 0, 0.117], // traced from Fig. 6
+        geometric_albedo: ['Galileo_SSI.Clear', 0.055, 0.0050], // Table V, log-scaled
+    },
+    '(J XIV) Thebe: Trailing side|Thomas1998': {
+        tags: ['Solar system', 'moon', 'Jovian system', 'regular'],
+        system: 'Galileo_SSI',
+        filters: ['Violet', 'Green', '8890A'],
+        br: [0.6, 1, 1.137], // traced from Fig. 6
+        sd: [0.05, 0, 0.117], // traced from Fig. 6
+        geometric_albedo: ['Galileo_SSI.Clear', 0.044, 0.0040], // Table V, log-scaled
+    },
     '(J I) Io: Trailing hemisphere|USGSarchive': {
         tags: ['featured', 'Solar system', 'planet geophysical', 'moon', 'Jovian system', 'regular'],
         nm: [350, 375, 400, 433, 466, 500, 533, 566, 600, 633, 666, 700, 733, 739.8, 751.9, 763.6, 775.6, 786.3, 799, 811.7, 822.4, 837.1, 849.8, 862.5],


### PR DESCRIPTION
Added traced colors for leading and trailing sides of Metis (T-only), Amalthea, and Thebe. Please verify accuracy before approving.