### PR TITLE
Albedo standardization comments, and tags (+ misc. QOL updates)

### DIFF
--- a/spectra/02_solar_system.json5
+++ b/spectra/02_solar_system.json5
@@ -58,6 +58,7 @@
     ],
 
     // Mercury
+    // by default, Mallama2017a is used for geometric albedo and Domingue2011 for spherical albedo
     'Domingue2011': [
         'Mercury’s spectrophotometric properties: Update from the Mercury Dual Imaging System observations during the third MESSENGER flyby',
         'DOI: 10.1016/j.pss.2011.04.012', 'https://www.sciencedirect.com/science/article/abs/pii/S0032063311001528',
@@ -74,7 +75,7 @@
         is_geometric_albedo: true,
         spherical_albedo: ['Messenger_MDIS_WAC.560BP5', 0.070],
     },
-    'Mercury | Mallama2017b, Domingue2011': {
+    'Mercury | Mallama2017b, Mallama2017a, Domingue2011': {
         tags: ['Solar System', 'planetary body/planet/Mercury'],
         file: 'spectra/files/Madden2018/Mercury_Mallama2017_Albedo.txtU',
         geometric_albedo: ['Generic_Bessell.V', 0.142],
@@ -95,11 +96,11 @@
         br_geometric: [0.119, 0.134, 0.152, 0.165, 0.180, 0.192, 0.214, 0.234, 0.247, 0.254],
         br_spherical: [0.053, 0.061, 0.070, 0.077, 0.084, 0.089, 0.098, 0.105, 0.110, 0.113],
     },
-    'Mercury | Crow2011, Payne2025, Domingue2011': { // phase angle 77°
+    'Mercury | Crow2011, Mallama2017a, Domingue2011': { // phase angle 77°
         tags: ['Solar System', 'planetary body/planet/Mercury'],
         nm: [314.7, 359.0, 392.6, 415.5, 457.5, 501.2, 626.4, 729.7, 959.5, 1063.5],
         br: [0.61, 0.56, 0.66, 0.71, 0.86, 1.00, 1.37, 1.50, 1.77, 2.01],
-        geometric_albedo: ['Generic_Bessell.V', 0.138],
+        geometric_albedo: ['Generic_Bessell.V', 0.142],
         spherical_albedo: ['Messenger_MDIS_WAC.560BP5', 0.070],
     },
 
@@ -265,6 +266,7 @@
     },
 
     // Terran system
+    // by default, Robinson2025 is used for geometric albedo and spherical albedo
     'Robinson2025': [
         'Inferring and Interpreting the Visual Geometric Albedo and Phase Function of Earth',
         'DOI: 10.3847/PSJ/ae2ec6', 'https://iopscience.iop.org/article/10.3847/PSJ/ae2ec6',
@@ -276,7 +278,7 @@
         'https://scixplorer.org/abs/2018JQSRT.217...86V/abstract'
     ],
     'Earth: Synthetic spectrum | Villanueva2018, Payne2025, Robinson2025': { // see Payne2025 for the processing methods
-        tags: ['featured', 'Solar System', 'planetary body/planet/Earth'],
+        tags: ['featured', 'Solar System/Terran system', 'planetary body/planet/Earth'],
         file: 'spectra/files/Payne2025/earth_composite_data.txtU',
         is_geometric_albedo: true,
         spherical_albedo: ['Misc_Atlas.cyan', [0.294, 0.002]], // "broadband visual albedo", Misc_Atlas.cyan was the closest one
@@ -287,14 +289,14 @@
         'https://scixplorer.org/abs/2018BAMS...99.1829M/abstract'
     ],
     'Earth | Marshak2018, Payne2025, Robinson2025': {
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         photometric_system: 'DSCOVR_EPIC',
         filters: ['317nm', '325nm', '388nm', '443nm', '551nm', '680nm', '779nm'],
         br_geometric: [0.182, 0.276, 0.300, 0.268, 0.211, 0.205, 0.232], // Fig. 4
         spherical_albedo: ['Misc_Atlas.cyan', [0.294, 0.002]], // "broadband visual albedo", Misc_Atlas.cyan was the closest one
     },
     'Earth | Robinson2025': {
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         photometric_system: 'Generic_Bessell',
         filters: ['B', 'V', 'R'],
         br_geometric: [[0.277, +0.005, -0.004], [0.226, 0.004], [0.221, 0.004]],
@@ -306,7 +308,7 @@
         'https://ui.adsabs.harvard.edu/abs/2011AsBio..11..907L/abstract'
     ],
     'Earth | Livengood2011, Payne2025, Robinson2025': {
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         photometric_system: 'DeepImpact_HRI-VIS',
         filters: ['Violet', 'Blue', 'Green', 'Orange', 'Red', 'NIR', 'IR'],
         br: [0.295, 0.229, 0.177, 0.168, 0.171, 0.189, 0.152], // phase-corrected values reported in Payne2025 (Fig. 4)
@@ -314,7 +316,7 @@
         spherical_albedo: ['Misc_Atlas.cyan', [0.294, 0.002]], // "broadband visual albedo", Misc_Atlas.cyan was the closest one
     },
     'Earth | Crow2011, Robinson2025': { // phase angle 75.1°
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         photometric_system: 'DeepImpact_HRI-VIS',
         filters: ['Violet', 'Blue', 'Green', 'Orange', 'Red', 'NIR', 'IR'],
         br: [1610.47, 1342.71, 1059.02, 1014.27, 1062.25, 1168.00, 853.79],
@@ -327,7 +329,7 @@
         'http://scixplorer.org/abs/2024AJ....167...87S/abstract'
     ],
     'Earth | Strauss2024, Robinson2025': {
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         photometric_system: 'Galileo_SSI',
         filters: ['Violet', 'Green', 'Red', '7270A', '7560A', '9680A'],
         br: [[0.381, 0.026], [0.262, 0.008], [0.252, 0.012], [0.252, 0.016], [0.227, 0.013], [0.245, 0.013]], // Fig. 7 (Galileo 1990)
@@ -340,13 +342,13 @@
         'https://ui.adsabs.harvard.edu/abs/2014ApJ...787..171R/abstract'
     ],
     'Earth | Robinson2014, Robinson2025': { // phase angle 23°
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         file: 'spectra/files/Earth_Robinson2014.txtU', // Fig. 4 (Full-disk)
         geometric_albedo: ['Generic_Bessell.V', [0.226, 0.004]],
         spherical_albedo: ['Misc_Atlas.cyan', [0.294, 0.002]], // "broadband visual albedo", Misc_Atlas.cyan was the closest one
     },
     'Earth | Mallama2017a, Robinson2025': {
-        tags: ['Solar System', 'planetary body/planet/Earth'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth'],
         filters: ['Generic_Bessell.U', 'Generic_Bessell.B', 'Generic_Bessell.V', 'Generic_Bessell.R', 'Generic_Bessell.I',
                   'Generic_Cousins.R', 'Generic_Cousins.I'],
         br: [0.688, 0.512, 0.434, 0.418, 0.430,
@@ -355,17 +357,17 @@
         spherical_albedo: ['Misc_Atlas.cyan', [0.294, 0.002]], // "broadband visual albedo", Misc_Atlas.cyan was the closest one
     },
     'Earth: Archean | VPL': { // Arney et al. 2017, "Hazy Archean Earth orbiting the Archean Sun", 1 bar, 1% CO2, 0.2% CH4
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth history'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Earth history'],
         file: 'spectra/files/VPL/HAZE_archeansun.pt_toa.txtU', // synthetic spectrum
         is_spherical_albedo: true, // at quadrature?
     },
     'Earth: Proterozoic | VPL': { // Arney et al. 2016, 1 bar, 1% CO2, 0.03% CH4, 1% LAP O2
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth history'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Earth history'],
         file: 'spectra/files/VPL/hi_o2_proterozoic_toa.txtU', // synthetic spectrum
         is_spherical_albedo: true, // at quadrature?
     },
     'Earth: Synthetic spectrum | VPL, Robinson2025': { // Robinson et al. 2011, "True disk-integrated Earth"
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth history'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Earth history'],
         file: 'spectra/files/VPL/earth_quadrature_radiance_refl.txtU', // synthetic spectrum
         geometric_albedo: ['Generic_Bessell.V', [0.226, 0.004]],
         spherical_albedo: ['Misc_Atlas.cyan', [0.294, 0.002]], // "broadband visual albedo", Misc_Atlas.cyan was the closest one
@@ -379,22 +381,22 @@
     // reflectance for optical depth of 10 without surface reflection and atmospheric scattering and gaseous
     // absorption."
     'Surface of Earth: Deserted land | Wen2019': {
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth surface feature'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Terran feature'],
         file: 'spectra/files/Wen2019/Land.txt', // Fig. 2a
         is_albedo: true, // reflectance
     },
     'Surface of Earth: Vegetated land | Wen2019': {
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth surface feature'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Terran feature'],
         file: 'spectra/files/Wen2019/Vegetation.txt', // Fig. 2a
         is_albedo: true, // reflectance
     },
     'Clouds of Earth | Wen2019': {
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth surface feature'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Terran feature'],
         file: 'spectra/files/Wen2019/Cloud.txt', // Fig. 2a
         is_albedo: true, // reflectance
     },
     'Oceans of Earth | Wen2019': {
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth surface feature'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Terran feature'],
         file: 'spectra/files/Wen2019/Ocean.txt', // Fig. 2a
         is_albedo: true, // reflectance
     },
@@ -404,12 +406,14 @@
         'https://ui.adsabs.harvard.edu/abs/2014GeofI..53..385G/abstract'
     ],
     'Caribbean Sea (Earth) | Gómez2014': {
-        tags: ['Solar System', 'planetary body/planet/Earth/Earth surface feature'],
+        tags: ['Solar System/Terran system', 'planetary body/planet/Earth/Terran feature'],
         nm: [380, 400, 425, 450, 475, 500, 520, 550, 600, 650, 700],
         br: [0.048, 0.047, 0.043, 0.037, 0.032, 0.02, 0.01, 0.007, 0.004, 0.002, 0.001],
         is_albedo: true,
     },
     // Moon
+    // by default, Lane1973 is used for the near side's geometric albedo and spherical albedo,
+    // and Caron2020 is used for the far side's geometric albedo and Warell2004 for phase integral
     'Velikodsky2011': [
         'New Earth-based absolute photometry of the Moon',
         'DOI: 10.1016/j.icarus.2011.04.021', 'https://www.sciencedirect.com/science/article/abs/pii/S0019103511001564',
@@ -425,7 +429,7 @@
         'DOI: 10.1086/111414', 'https://ui.adsabs.harvard.edu/abs/1973AJ.....78..267L/abstract'
     ],
     'Moon: Near side (E I) | Crow2011, Lane1973': { // phase angle 97.6°
-        tags: ['featured', 'Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['featured', 'Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         photometric_system: 'DeepImpact_HRI-VIS',
         filters: ['Violet', 'Blue', 'Green', 'Orange', 'Red', 'NIR', 'IR'],
         br: [1894.24, 2387.17, 2832.17, 3269.35, 4091.49, 4787.91, 5506.36],
@@ -433,14 +437,14 @@
         spherical_albedo: ['Generic_Bessell.V', 0.069],
     },
     'Moon: Near side (E I) | Velikodsky2011': { // linear combination of highland and mare spectra with the weights 0.57 and 0.43, respectively
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         file: 'spectra/files/Velikodsky2011/moon_average.txt',
         // linear combination of the mean highland and mare locations, Table 3:
         phase_function: ['Cameras_Canon.300D_R', 'exponentials', {A_1: 0.0539, mu_1: 50, A_2: 0.0465, mu_2: 5.615, A_3: 0.1145, mu_3: 0.6135}],
         // spherical albedo derived from the phase function is twice as high because the function doesn't go to 0 at 180°
     },
     'Moon: Near side (E I) | Hillier1999': { // 32% Maria and 68% highlands
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         photometric_system: 'Clementine_UVVIS',
         filters: ['415nm', '750nm', '900nm', '950nm', '1000nm'],
         br_geometric: [0.176, 0.246, 0.252, 0.246, 0.231],
@@ -449,7 +453,7 @@
         sd_spherical: [0.001, 0.002, 0.002, 0.003, 0.002],
     },
     'Moon: Near side (E I) | Lane1973': {
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         nm: [359.0, 392.6, 415.5, 457.3, 501.2, 626.4, 729.7, 859.5, 1063.5],
         br_geometric: [0.072, 0.085, 0.088, 0.098, 0.106, 0.162, 0.179, 0.179, 0.202], // excludes opposition effect
         br_spherical: [0.039, 0.049, 0.048, 0.056, 0.062, 0.098, 0.113, 0.118, 0.136],
@@ -470,13 +474,13 @@
         'https://ui.adsabs.harvard.edu/abs/2004Icar..167..271W/abstract'
     ],
     'Moon: Far side (E I) | Holsclaw2010, Caron2020, Warell2004': { // phase angle 65°
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         file: 'spectra/files/Moon_Holsclaw2010.txt', // Fig. 5a (MASCS)
         geometric_albedo: ['Clementine_UVVIS.750nm', 0.27], // derived from Fig. 1b
         phase_integral: [0.452, 0.004],
     },
     'Moon: Far side (E I) | Crow2011, Caron2020, Warell2004': { // phase angle 75.1°
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         photometric_system: 'DeepImpact_HRI-VIS',
         filters: ['Violet', 'Blue', 'Green', 'Orange', 'Red', 'NIR', 'IR'],
         br: [13.83, 18.06, 22.54, 26.68, 30.74, 34.86, 34.14],
@@ -484,14 +488,14 @@
         phase_integral: [0.452, 0.004],
     },
     'Moon: Highlands (E I) | Velikodsky2011': {
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         file: 'spectra/files/Velikodsky2011/moon_highland.txt',
         // mean of 4 locations, Table 3:
         phase_function: ['Cameras_Canon.300D_R', 'exponentials', {A_1: 0.0715, mu_1: 50, A_2: 0.0525, mu_2: 5.325, A_3: 0.1457, mu_3: 0.5875}],
         // spherical albedo derived from the phase function is twice as high because the function doesn't go to 0 at 180°
     },
     'Moon: Highlands (E I) | Hillier1999': {
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         photometric_system: 'Clementine_UVVIS',
         filters: ['415nm', '750nm', '900nm', '950nm', '1000nm'],
         br_geometric: [0.20, 0.28, 0.29, 0.28, 0.29],
@@ -500,14 +504,14 @@
         sd_spherical: [0.002, 0.002, 0.003, 0.004, 0.003],
     },
     'Moon: Maria (E I) | Velikodsky2011': {
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         file: 'spectra/files/Velikodsky2011/moon_mare.txt',
         // mean of 5 locations, Table 3:
         phase_function: ['Cameras_Canon.300D_R', 'exponentials', {A_1: 0.0306, mu_1: 50, A_2: 0.0386, mu_2: 6.0, A_3: 0.073, mu_3: 0.6480}],
         // spherical albedo derived from the phase function is twice as high because the function doesn't go to 0 at 180°
     },
     'Moon: Maria (E I) | Hillier1999': {
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         photometric_system: 'Clementine_UVVIS',
         filters: ['415nm', '750nm', '900nm', '950nm', '1000nm'],
         br_geometric: [0.13, 0.17, 0.18, 0.17, 0.16],
@@ -521,25 +525,26 @@
         'https://ui.adsabs.harvard.edu/abs/2018AJ....155..213W/abstract'
     ],
     "Guang Han Gong: Chang'e-3 Landing Site (Moon) | Wu2018": {
-        tags: ['Solar System', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
+        tags: ['Solar System/Terran system', 'planetary body/large moon/Moon', 'natural satellite/regular moon'],
         file: 'spectra/files/Moon_CE-3_LS_Wu2018.txt',
         is_albedo: true, // angle of incidence 54°, angle of emergence 44°, phase angle 95°; See Section 3.2
     },
 
     // Martian system
+    // by default, Mallama2017a is used for geometric albedo and Pleskot1977 for phase integral
     'Pleskot1977': [
         'The Infrared Photometric Function of Mars and Its Bolometric Albedo',
         'DOI: 10.1016/0019-1035(77)90169-5', 'https://www.sciencedirect.com/science/article/pii/0019103577901695',
         'https://ui.adsabs.harvard.edu/abs/1977Icar...30..341P/abstract'
     ],
     'Mars | Madden2018, Pleskot1977': {
-        tags: ['featured', 'Solar System', 'planetary body/planet/Mars'],
+        tags: ['featured', 'Solar System/Martian system', 'planetary body/planet/Mars'],
         file: 'spectra/files/Madden2018/Mars_McCord1971_Albedo.txtU',
         is_geometric_albedo: true,
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
     },
     'Mars | Mallama2017a, Pleskot1977': { // synthetic photospectrum
-        tags: ['Solar System', 'planetary body/planet/Mars'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars'],
         filters: ['Generic_Bessell.U', 'Generic_Bessell.B', 'Generic_Bessell.V', 'Generic_Bessell.R', 'Generic_Bessell.I',
                   'Generic_Cousins.R', 'Generic_Cousins.I'],
         br_geometric: [0.060, 0.088, 0.170, 0.288, 0.330,
@@ -547,7 +552,7 @@
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
     },
     'Mars | Crow2011, Mallama2017a, Pleskot1977': { // phase angle 37.0°
-        tags: ['Solar System', 'planetary body/planet/Mars'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars'],
         photometric_system: 'DeepImpact_HRI-VIS',
         filters: ['Violet', 'Blue', 'Green', 'Orange', 'Red', 'NIR', 'IR'],
         br: [4.52, 6.87, 13.09, 21.60, 25.32, 26.55, 24.31],
@@ -555,13 +560,13 @@
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
     },
     'Mars: Synthetic spectrum | VPL, Pleskot1977': { // Tyler Robinson, "Present-day Mars generated using SMART"
-        tags: ['Solar System', 'planetary body/planet/Mars'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars'],
         file: 'spectra/files/VPL/mars_flx_refl.txtU',
         is_geometric_albedo: true,
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
     },
     'Mars: Synthetic spectrum | Payne2025, Pleskot1977': {
-        tags: ['Solar System', 'planetary body/planet/Mars'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars'],
         file: 'spectra/files/Payne2025/mars_composite_data.txtU',
         is_geometric_albedo: true,
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
@@ -572,13 +577,13 @@
         'https://ui.adsabs.harvard.edu/abs/1979JGR....84.8415S/abstract'
     ],
     'Mars: Bright areas | Singer1979, Pleskot1977': { // the average of a number of typical bright region spectra
-        tags: ['Solar System', 'planetary body/planet/Mars/Martian surface feature'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars/Martian feature'],
         file: 'spectra/files/Singer1979/Mars_bright.txtU', // figure 3
         geometric_albedo: [800, 0.40],
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
     },
     'Mars: Dark areas | Singer1979, Pleskot1977': { // telescopic dark region Iapygia
-        tags: ['Solar System', 'planetary body/planet/Mars/Martian surface feature'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars/Martian feature'],
         file: 'spectra/files/Singer1979/Mars_dark.txtU', // figure 3
         geometric_albedo: [800, 0.21],
         phase_integral: 1.01, // extracted from Fig. 7 for 550 nm (q2)
@@ -589,16 +594,17 @@
         'https://ui.adsabs.harvard.edu/abs/2007Icar..191..581B/abstract'
     ],
     'Olympus Mons (Mars) | Bell2007': {
-        tags: ['Solar System', 'planetary body/planet/Mars/Martian surface feature'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars/Martian feature'],
         file: 'spectra/files/Bell2007/Olympus_Mons_Bell2007.txt', // Fig 3. (2003: Clear)
         is_albedo: true, // I/F
     },
     'Valles Marineris: Eastern part (Mars) | Bell2007': {
-        tags: ['Solar System', 'planetary body/planet/Mars/Martian surface feature'],
+        tags: ['Solar System/Martian system', 'planetary body/planet/Mars/Martian feature'],
         file: 'spectra/files/Bell2007/Valles_Marineris_Bell2007.txt', // Fig 3. (2003: Clear)
         is_albedo: true, // I/F
     },
     // Phobos
+    // by default, Fornasier2024a is used for geometric albedo and spherical albedo
     'Pajola2013': [
         'Phobos as a D-type Captured Asteroid, Spectral Modeling from 0.25 to 4.0 μm',
         'DOI: 10.1088/0004-637X/777/2/127', 'https://iopscience.iop.org/article/10.1088/0004-637X/777/2/127',
@@ -610,7 +616,7 @@
         'https://ui.adsabs.harvard.edu/abs/2024A%26A...686A.203F/abstract'
     ],
     'Phobos (M I) | Pajola2013, Fornasier2024a': {
-        tags: ['featured', 'Solar System', 'natural satellite/regular moon'],
+        tags: ['featured', 'Solar System/Martian system', 'natural satellite/regular moon'],
         filters: [
             'Rosetta_OSIRIS_WAC.UV245', 'Rosetta_OSIRIS_WAC.CS', 'Rosetta_OSIRIS_NAC.Far_UV', 'Rosetta_OSIRIS_WAC.UV295',
             'Rosetta_OSIRIS_WAC.OH', 'Rosetta_OSIRIS_WAC.NH', 'Rosetta_OSIRIS_NAC.Near_UV', 'Rosetta_OSIRIS_WAC.UV375',
@@ -631,6 +637,7 @@
         spherical_albedo: ['MEX_HRSC.Green', 0.0157], // disk-resolved (Table 3)
     },
     // Deimos
+    // by default, Wargnier2025 is used for geometric albedo and spherical albedo
     'Fraeman2013': [
         'Spectral absorptions on Phobos and Deimos in the visible/near infrared wavelengths and their compositional constraints',
         'DOI: 10.1016/j.icarus.2013.11.021', 'https://www.sciencedirect.com/science/article/abs/pii/S0019103513004934',
@@ -642,7 +649,7 @@
         'https://ui.adsabs.harvard.edu/abs/2025arXiv250912804W/abstract'
     ],
     'Deimos (M II) | Fraeman2013, Wargnier2025': {
-        tags: ['featured', 'Solar System', 'natural satellite/regular moon'],
+        tags: ['featured', 'Solar System/Martian system', 'natural satellite/regular moon'],
         nm: [250, 300, 350, 400, 450, 500, 550, 600, 700, 750, 800],
         br: [0.04, 0.05, 0.051, 0.05, 0.049, 0.053, 0.055, 0.058, 0.062, 0.067, 0.069],
         geometric_albedo: ['MEX_SRC.Pan', [0.080, 0.001]], // Table 4
@@ -650,6 +657,7 @@
     },
 
     // Jovian system
+    // by default, Li2018 is used for geometric albedo and spherical albedo
     'Li2018': [
         'Less absorbed solar energy and more internal heat for Jupiter',
         'DOI: 10.1038/s41467-018-06107-2', 'https://www.nature.com/articles/s41467-018-06107-2',
@@ -685,12 +693,13 @@
         'DOI: 10.1088/2041-8205/715/2/L150', 'https://iopscience.iop.org/article/10.1088/2041-8205/715/2/L150',
         'https://scixplorer.org/abs/2010ApJ...715L.150H/abstract'
     ],
+    // WFPC2 methane filters were removed due to spectral artefacts
     'Jupiter: 34° S, 1994 | Hammel2010': {
         tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter'],
         photometric_system: 'HST_WFPC2-WF',
-        filters: ['F255W', 'F336W', 'F410M', 'F555W', 'FQCH4N_C', 'F953N'], // Filters from Table 1 of West et al. (1995)
-        br: [0.339, 0.305, 0.421, 0.528, 0.055, 0.514],
-        sd: [0.016, 0.015, 0.021, 0.027, 0.007, 0.027], // Fig. 2a
+        filters: ['F255W', 'F336W', 'F410M', 'F555W', 'F953N'], // Filters from Table 1 of West et al. (1995)
+        br: [0.339, 0.305, 0.421, 0.528, 0.514],
+        sd: [0.016, 0.015, 0.021, 0.027, 0.027], // Fig. 2a
         is_albedo: true, // Reflectivity
     },
     'Jupiter: 58° S, 2009 | Hammel2010': {
@@ -717,7 +726,7 @@
         'https://ui.adsabs.harvard.edu/abs/2018AJ....155..151S/abstract'
     ],
     'Great Red Spot: February 1995 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFPC2-PC',
         filters: ['F336W', 'F410M', 'F555W', 'F673N', 'F953N'],
         br: [0.257, 0.390, 0.638, 0.799, 0.697],
@@ -726,7 +735,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: October 1996 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFPC2-PC',
         filters: ['F410M', 'F555W', 'F673N', 'F953N'],
         br: [0.334, 0.661, 0.818, 0.704],
@@ -735,7 +744,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: February 2007 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFPC2-PC',
         filters: ['F255W', 'F343N', 'F410M', 'F673N', 'F953N'],
         br: [0.255, 0.252, 0.395, 0.790, 0.682],
@@ -744,7 +753,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: June 2008 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFPC2-PC',
         filters: ['F255W', 'F343N', 'F375N', 'F390N', 'F410M', 'F437N', 'F469N', 'F502N', 'F673N'],
         br: [0.283, 0.290, 0.327, 0.348, 0.416, 0.465, 0.542, 0.633, 0.820],
@@ -753,7 +762,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: November 2009 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFC3_UVIS1',
         filters: ['F275W', 'FQ378N', 'FQ437N', 'FQ508N', 'FQ634N', 'FQ906N'],
         br: [0.304, 0.312, 0.476, 0.678, 0.794, 0.448], // uncertainties are smaller than the symbol size
@@ -761,7 +770,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: April 2014 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFC3_UVIS1',
         filters: ['F395N', 'F467M', 'F487N', 'F502N', 'F631N'],
         br: [0.220, 0.406, 0.450, 0.489, 0.748], // uncertainties are smaller than the symbol size
@@ -769,7 +778,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: January 2015 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFC3_UVIS1',
         filters: ['F275W', 'F343N', 'F395N', 'F467M', 'F502N', 'F547M', 'F631N', 'F658N'],
         br: [0.200, 0.156, 0.204, 0.365, 0.516, 0.569, 0.700, 0.718], // uncertainties are smaller than the symbol size
@@ -777,7 +786,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: February 2016 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFC3_UVIS1',
         filters: ['F275W', 'F343N', 'F395N', 'F467M', 'F502N', 'F547M', 'F631N', 'F658N'],
         br: [0.195, 0.128, 0.167, 0.328, 0.424, 0.518, 0.697, 0.732], // uncertainties are smaller than the symbol size
@@ -785,7 +794,7 @@
         is_albedo: true, // I/F
     },
     'Great Red Spot: April 2017 (Jupiter) | Simon2018': {
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/GRS'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature/GRS'],
         photometric_system: 'HST_WFC3_UVIS1',
         filters: ['F275W', 'F343N', 'F395N', 'F467M', 'F502N', 'F547M', 'F631N', 'F658N'],
         br: [0.190, 0.120, 0.157, 0.321, 0.398, 0.515, 0.721, 0.752], // uncertainties are smaller than the symbol size
@@ -793,15 +802,15 @@
         is_albedo: true, // I/F
     },
     'D/Shoemaker–Levy 9 impact site: Fragment-E (Jupiter) | Hammel2010': { // August 24 1994 according to West et al. (1995)
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature'],
         photometric_system: 'HST_WFPC2-WF',
-        filters: ['F255W', 'F336W', 'F410M', 'F555W', 'FQCH4N_C', 'F953N'], // Filters from Table 1 of West et al. (1995)
-        br: [0.138, 0.130, 0.157, 0.162, 0.109, 0.202],
-        sd: [0.030, 0.007, 0.006, 0.005, 0.008, 0.006], // Fig. 2a
+        filters: ['F255W', 'F336W', 'F410M', 'F555W', 'F953N'], // Filters from Table 1 of West et al. (1995)
+        br: [0.138, 0.130, 0.157, 0.162, 0.202],
+        sd: [0.030, 0.007, 0.006, 0.005, 0.006], // Fig. 2a
         is_albedo: true, // Reflectivity
     },
     'Wesley impact impact site: Core, 56° S (Jupiter) | Hammel2010': { // July 23 and August 8 2009
-        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter'],
+        tags: ['Solar System/Jovian system', 'planetary body/planet/Jupiter/Jovian feature'],
         photometric_system: 'HST_WFC3_UVIS1',
         filters: ['F225W', 'F275W', 'FQ378N', 'FQ437N', 'FQ508N', 'FQ634N', 'FQ727N', 'FQ889N', 'FQ906N', 'FQ924N'], // Filters from Table 1
         br: [0.104, 0.079, 0.115, 0.141, 0.140, 0.179, 0.128, 0.097, 0.168, 0.216],
@@ -935,6 +944,7 @@
         'http://scixplorer.org/abs/2025PSJ.....6..161D/abstract'
     ],
     // Io
+    // by default, Domingue1998 is used for geometric albedo and phase integral
     'Simonelli1984': [
         'Voyager Disk-Integrated Photometry of Io',
         'DOI: 10.1016/0019-1035(84)90110-6', 'https://www.sciencedirect.com/science/article/abs/pii/0019103584901106',
@@ -1115,6 +1125,7 @@
         is_emissive: true,
     },
     // Europa
+    // by default, Madden2018 is used for geometric albedo and Grundy2007a for phase integral
     'Trumbo2019': [
         'Sodium chloride on the surface of Europa',
         'DOI: 10.1126/sciadv.aaw7123', 'https://www.science.org/doi/10.1126/sciadv.aaw7123',
@@ -1220,6 +1231,7 @@
         is_emissive: true,
     },
     // Ganymede
+    // by default, Madden2018 is used for geometric albedo and Buratti1991 for phase integral
     'Ganymede: Leading hemisphere (J III) | Davis2025, Madden2018, Buratti1991': {
         tags: ['featured', 'Solar System/Jovian system', 'planetary body/large moon/Ganymede', 'natural satellite/regular moon'],
         file: 'spectra/files/Davis2025/Ganymede_Leading.txt', // Fig. 11
@@ -1275,6 +1287,7 @@
         is_emissive: true,
     },
     // Callisto
+    // by default, Madden2018 is used for geometric albedo and Buratti1991 for phase integral
     'Callisto: Leading hemisphere (J IV) | Davis2025, Madden2018, Buratti1991': {
         tags: ['featured', 'Solar System/Jovian system', 'planetary body/large moon/Callisto', 'natural satellite/regular moon'],
         file: 'spectra/files/Davis2025/Callisto_Leading.txt', // Fig. 11
@@ -1308,6 +1321,7 @@
     },
 
     // Saturnian system
+    // by default, Karkoschka1998 is used for geometric albedo and Dyudina2016b for phase integral
     'Dyudina2016b': [
         'Reflected Light Curves, Spherical and Bond Albedos of Jupiter- and Saturn-like Exoplanets',
         'DOI: 10.3847/0004-637X/822/2/76', 'https://iopscience.iop.org/article/10.3847/0004-637X/822/2/76',
@@ -1644,6 +1658,7 @@
         geometric_albedo: [611, [0.25, 0.23]],
     },
     // Mimas
+    // by default, Buratti2022 is used for geometric albedo and phase integral
     'Mimas (S I) | Filacchione2022, Buratti2022': {
         tags: ['featured', 'Solar System/Saturnian system', 'planetary body/large moon/Mimas', 'natural satellite/regular moon'],
         file: 'spectra/files/Filacchione2022/Mimas.txt', // equigonal albedo
@@ -1666,6 +1681,7 @@
         geometric_albedo: [611, [0.47, 0.11]],
     },
     // Enceladus
+    // by default, Buratti2022 is used for geometric albedo and phase integral
     'Enceladus (S II) | Madden2018, Buratti2022': {
         tags: ['featured', 'Solar System/Saturnian system', 'planetary body/large moon/Enceladus', 'natural satellite/regular moon'],
         file: 'spectra/files/Madden2018/Enceladus_VIMS_Albedo.txtU',
@@ -1679,6 +1695,7 @@
         phase_integral: [0.79, 0.01],
     },
     // Tethys
+    // by default, Buratti2022 is used for geometric albedo and phase integral
     'Filacchione2018': [
         'Photometric Modeling and VIS-IR Albedo Maps of Tethys From Cassini-VIMS',
         'DOI: 10.1029/2018GL078602', 'https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2018GL078602',
@@ -1716,6 +1733,7 @@
         geometric_albedo: ['HST_WFPC2-PC.F555W', [1.34, 0.10]],
     },
     // Dione
+    // by default, Buratti2022 is used for geometric albedo and phase integral
     'Filacchione2017': [
         'Photometric Modeling and VIS-IR Albedo Maps of Dione From Cassini-VIMS',
         'DOI: 10.1002/2017GL076869', 'https://agupubs.onlinelibrary.wiley.com/doi/full/10.1002/2017GL076869',
@@ -1772,6 +1790,7 @@
         geometric_albedo: ['Generic_Bessell.V', [1.24, 0.09]], // Table 2, p. 325 (Verbiscer2018)
     },
     // Rhea
+    // by default, Buratti2022 is used for geometric albedo and phase integral
     'Clark1984': [
         'Saturn’s satellites: Near-infrared spectrophotometry (0.6-2.5 μm) of the leading and trailing sides and compositional implications',
         'DOI: 10.1016/0019-1035(84)90043-5', 'https://www.sciencedirect.com/science/article/abs/pii/0019103584900435',
@@ -1806,6 +1825,7 @@
         phase_integral: [0.65, 0.06], // 510 nm
     },
     // Titan
+    // by default, Karkoschka1998 is used for geometric albedo and Muñoz2017 for phase integral
     'Karkoschka2012': [
         'The reflectivity spectrum and opposition effect of Titan’s surface observed by Huygens’ DISR spectrometers',
         'DOI: 10.1016/j.pss.2011.10.014', 'https://www.sciencedirect.com/science/article/pii/S0032063311003254',
@@ -1876,6 +1896,7 @@
         is_albedo: true,
     },
     // Hyperion
+    // by default, Verbiscer2018 is used for geometric albedo and Howard2012 for bond albedo
     'Hicks2008': [
         'BVR photometry of Hyperion near the time of the 2005 Cassini encounter',
         'DOI: 10.1016/j.icarus.2007.06.021', 'https://www.sciencedirect.com/science/article/abs/pii/S0019103507002990',
@@ -1916,6 +1937,7 @@
         bond_albedo: [0.33, 0.05],
     },
     // Iapetus
+    // by default, Blackburn2010 is used for geometric albedo and phase integral
     'Filacchione2007': [
         'Saturn’s icy satellites investigated by Cassini-VIMS. I. Full-disk properties: 350 5100 nm reflectance spectra and phase curves',
         'DOI: 10.1016/j.icarus.2006.08.001', 'https://www.sciencedirect.com/science/article/abs/pii/S0019103506002715',
@@ -1973,6 +1995,7 @@
         spherical_albedo: [530, 0.08], // average of 60° − 80° N on leading hemisphere in Fig. 6A (Blackburn2011)
     },
     // Phoebe
+    // by default, Miller2011 is used for geometric albedo and spherical albedo
     'Miller2011': [
         'Comparing Phoebe’s 2005 opposition surge in four visible light filters',
         'DOI: 10.1016/j.icarus.2010.12.024', 'https://www.sciencedirect.com/science/article/abs/pii/S0019103510004926',
@@ -2039,6 +2062,7 @@
     },
 
     // Uranian system
+    // by default, Karkoschka1998 is used for geometric albedo and Irwin2025 for phase integral
     'Irwin2025': [
         'The bolometric Bond albedo and energy balance of Uranus',
         'DOI: 10.48550/arXiv.2502.18971', 'https://arxiv.org/abs/2502.18971',
@@ -2255,6 +2279,7 @@
         'https://zenodo.org/records/18745327', 'https://scixplorer.org/abs/2026PSJ.....7...67D/abstract',
     ],
     // Miranda
+    // by default, Karkoschka2001 is used for geometric albedo and spherical albedo
     'Miranda (U V) | Avramchuk2007, Karkoschka2001': {
         tags: ['featured', 'Solar System/Uranian system', 'planetary body/large moon/Miranda', 'natural satellite/regular moon'],
         nm: [250, 410, 480, 560, 750, 910, 1400, 1800],
@@ -2283,6 +2308,7 @@
         'DOI: 10.1016/0019-1035(89)90041-9', 'https://www.sciencedirect.com/science/article/pii/0019103589900419',
         'https://ui.adsabs.harvard.edu/abs/1989Icar...82..314H/abstract'
     ],
+    // the Clear filter was removed, reconstructed spectra should be pink and blue to fit it
     'Miranda (U V) | Hillier1989, Karkoschka2001': { // B0 (16°) = 0.225-0.275
         tags: ['Solar System/Uranian system', 'planetary body/large moon/Miranda', 'natural satellite/regular moon'],
         photometric_system: 'Voyager_ISS-NAC',
@@ -2301,7 +2327,17 @@
         geometric_albedo: ['Voyager_ISS-NAC.Clear', 0.33], // Normal reflectance (Table IV)
         phase_integral: [0.44, 0.05],
     },
+    'Miranda: Dark areas (U V) | Hillier1989, Karkoschka2001': { // B0 (16°) < 0.225
+        tags: ['Solar System/Uranian system', 'planetary body/large moon/Miranda', 'natural satellite/regular moon'],
+        photometric_system: 'Voyager_ISS-NAC',
+        filters: ['Violet', 'Green'],
+        br: [1.088, 1], // V/Cl ratio: 1.076 ±0.029, G/Cl ratio: 0.986 ±0.027
+        sd: [0.029, 0],
+        geometric_albedo: ['Voyager_ISS-NAC.Clear', 0.27], // Normal reflectance (Table IV)
+        phase_integral: [0.44, 0.05],
+    },
     // Ariel
+    // by default, Karkoschka2001 is used for geometric albedo and spherical albedo
     'Ariel (U I) | DeColibus2026, Karkoschka2001': {
         tags: ['featured', 'Solar System/Uranian system', 'planetary body/large moon/Ariel', 'natural satellite/regular moon'],
         file: 'spectra/files/DeColibus2026/Ariel_All_BothTel_GAvg.txtU',
@@ -2344,6 +2380,7 @@
         spherical_albedo: [550, [0.230, 0.025]],
     },
     // Umbriel
+    // by default, Karkoschka2001 is used for geometric albedo and spherical albedo
     'Umbriel (U II) | DeColibus2026, Karkoschka2001': {
         tags: ['featured', 'Solar System/Uranian system', 'planetary body/large moon/Umbriel', 'natural satellite/regular moon'],
         file: 'spectra/files/DeColibus2026/Umbriel_All_BothTel_GAvg.txtU',
@@ -2386,6 +2423,7 @@
         spherical_albedo: [550, [0.100, 0.010]],
     },
     // Titania
+    // by default, DeColibus2026 is used for geometric albedo and Karkoschka2001 for phase integral
     'Titania (U III) | DeColibus2026, Karkoschka2001': {
         tags: ['featured', 'Solar System/Uranian system', 'planetary body/large moon/Titania', 'natural satellite/regular moon'],
         file: 'spectra/files/DeColibus2026/Titania_All_BothTel_GAvg.txtU',
@@ -2428,6 +2466,7 @@
         phase_integral: [0.46, 0.05],
     },
     // Oberon
+    // by default, DeColibus2026 is used for geometric albedo and Karkoschka2001 for phase integral
     'Oberon (U IV) | DeColibus2026, Karkoschka2001': {
         tags: ['featured', 'Solar System/Uranian system', 'planetary body/large moon/Oberon', 'natural satellite/regular moon'],
         file: 'spectra/files/DeColibus2026/Oberon_All_BothTel_GAvg.txtU',
@@ -2501,6 +2540,7 @@
     },
 
     // Neptunian system
+    // by default, Karkoschka1998 is used for geometric albedo and Neff1985 for phase integral
     'Neff1985': [
         'Bolometric albedos of Titan, Uranus, and Neptune',
         'DOI: 10.1016/0019-1035(85)90185-X', 'https://www.sciencedirect.com/science/article/abs/pii/001910358590185X',
@@ -2641,6 +2681,7 @@
         phase_function: ['phase coefficient', {beta: [0.037, 0.003]}],
     },
     // Triton
+    // by default, Helfenstein2025 is used for geometric albedo and spherical albedo
     'Tryka1999': [
         'A Visual Spectrum of Triton from the Hubble Space Telescope',
         'DOI: 10.1006/icar.1999.6224', 'https://www.sciencedirect.com/science/article/abs/pii/S0019103599962243',
@@ -2733,6 +2774,7 @@
         phase_integral: [0.934, +0.100, -0.016],
     },
     // Nereid
+    // by default, Kiss2016 is used for geometric albedo and Thomas1991b for phase integral
     'Kiss2016': [
         'Nereid from space: rotation, size and shape analysis from K2, Herschel and Spitzer observations',
         'DOI: 10.1093/mnras/stw081', 'https://academic.oup.com/mnras/article/457/3/2908/2588900',


### PR DESCRIPTION
- Useful comments for main solar system planets and moons specifying default albedo values, similar to what was added for Venus
- Terran and Martian system tags, and Jovian features tag (along with tag name formatting parity)
- Added Miranda's dark areas I forgot to add in previous commit, and removed WFPC2 CH4 filters